### PR TITLE
Client hang fix

### DIFF
--- a/Client/Forms/AMain.cs
+++ b/Client/Forms/AMain.cs
@@ -1,16 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
+﻿using System.Diagnostics;
 using System.IO.Compression;
 using System.Net;
-using System.Threading;
-using System.Windows.Forms;
-using System.Drawing;
-using System.Drawing.Drawing2D;
 using Client;
-using System.Linq;
 using Microsoft.Web.WebView2.Core;
+using System.Net.Http.Headers;
+using System.Net.Http.Handlers;
 using Client.Utils;
 
 namespace Launcher
@@ -21,7 +15,7 @@ namespace Launcher
         private int _fileCount, _currentCount;
 
         public bool Completed, Checked, CleanFiles, LabelSwitch, ErrorFound;
-        
+
         public List<FileInformation> OldList;
         public Queue<FileInformation> DownloadList = new Queue<FileInformation>();
         public List<Download> ActiveDownloads = new List<Download>();
@@ -82,7 +76,6 @@ namespace Launcher
                 _fileCount = 0;
                 _currentCount = 0;
 
-
                 _fileCount = DownloadList.Count;
 
                 ServicePointManager.DefaultConnectionLimit = Settings.P_Concurrency;
@@ -90,6 +83,8 @@ namespace Launcher
                 _stopwatch = Stopwatch.StartNew();
                 for (var i = 0; i < Settings.P_Concurrency; i++)
                     BeginDownload();
+
+
             }
             catch (EndOfStreamException ex)
             {
@@ -103,12 +98,12 @@ namespace Launcher
                 Completed = true;
                 SaveError(ex.ToString());
             }
+
+            _stopwatch.Stop();
         }
 
-        
-
         private void BeginDownload()
-        {           
+        {
             if (DownloadList.Count == 0)
             {
                 Completed = true;
@@ -120,8 +115,9 @@ namespace Launcher
             var download = new Download();
             download.Info = DownloadList.Dequeue();
 
-            Download(download);
+            DownloadFile(download);
         }
+
         private void CleanUp()
         {
             if (!CleanFiles) return;
@@ -141,7 +137,7 @@ namespace Launcher
                     if (!NeedFile(fileNames[i]))
                         File.Delete(fileNames[i]);
                 }
-                catch{}
+                catch { }
             }
         }
         public bool NeedFile(string fileName)
@@ -159,9 +155,7 @@ namespace Launcher
         {
             OldList = new List<FileInformation>();
 
-            //byte[] data = DownloadFile(PatchFileName);
             byte[] data = Download(Settings.P_PatchFileName);
-
             if (data != null)
             {
                 using MemoryStream stream = new MemoryStream(data);
@@ -216,7 +210,7 @@ namespace Launcher
             }
         }
 
-        public void Download(Download dl)
+        public void DownloadFile(Download dl)
         {
             var info = dl.Info;
             string fileName = info.FileName.Replace(@"\", "/");
@@ -228,113 +222,104 @@ namespace Launcher
 
             try
             {
-                using (WebClient client = new WebClient())
+                HttpClientHandler httpClientHandler = new() { AllowAutoRedirect = true };
+                ProgressMessageHandler progressMessageHandler = new(httpClientHandler);
+
+                progressMessageHandler.HttpReceiveProgress += (_, args) =>
                 {
-                    client.DownloadProgressChanged += (o, e) =>
-                        {
-                            dl.CurrentBytes = e.BytesReceived;
-                        };
-                    client.DownloadDataCompleted += (o, e) =>
-                        {
-                            if (e.Error != null)
-                            {
-                                File.AppendAllText(@".\Error.txt",
-                                       string.Format("[{0}] {1}{2}", DateTime.Now, info.FileName + " could not be downloaded. (" + e.Error.Message + ")", Environment.NewLine));
-                                ErrorFound = true;
 
-                                BeginDownload();
-                            }
-                            else
-                            {
-                                _currentCount++;
-                                _completedBytes += dl.CurrentBytes;
-                                dl.CurrentBytes = 0;
-                                dl.Completed = true;
+                    dl.CurrentBytes = args.BytesTransferred;
 
-                                BeginDownload(); // Start next download, file IO can wait.
+                };
 
-                                byte[] raw = e.Result;
+                using (HttpClient client = new(progressMessageHandler))
+                {
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    client.DefaultRequestHeaders.AcceptCharset.Clear();
+                    client.DefaultRequestHeaders.AcceptCharset.Add(new StringWithQualityHeaderValue("utf-8"));
 
-                                if (info.Compressed > 0 && info.Compressed != info.Length)
-                                {
-                                    raw = Decompress(e.Result);
-                                }
-
-                                var fileName = Settings.P_Client + info.FileName;
-                                var dirName = Path.GetDirectoryName(fileName);
-                                if (!Directory.Exists(dirName))
-                                    Directory.CreateDirectory(dirName);
-
-                                File.WriteAllBytes(fileName, raw);
-                                File.SetLastWriteTime(fileName, info.Creation);
-                            }
-                        };
-
-                    if (Settings.P_NeedLogin) client.Credentials = new NetworkCredential(Settings.P_Login, Settings.P_Password);
-
+                    if (Settings.P_NeedLogin)
+                    {
+                        string authInfo = Settings.P_Login + ":" + Settings.P_Password;
+                        authInfo = Convert.ToBase64String(System.Text.Encoding.Default.GetBytes(authInfo));
+                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authInfo);
+                    }
 
                     ActiveDownloads.Add(dl);
-                    client.DownloadDataAsync(new Uri(Settings.P_Host + fileName));
+
+                    var task = Task.Run(() => client
+                                    .GetAsync(new Uri($"{Settings.P_Host}{fileName}"), HttpCompletionOption.ResponseHeadersRead));
+
+                    var response = task.Result;
+
+                    using Stream sm = response.Content.ReadAsStream();
+                    using MemoryStream ms = new();
+                    sm.CopyTo(ms);
+                    byte[] data = ms.ToArray();
+
+                    _currentCount++;
+                    _completedBytes += dl.CurrentBytes;
+                    dl.CurrentBytes = 0;
+                    dl.Completed = true;
+
+                    if (info.Compressed > 0 && info.Compressed != info.Length)
+                    {
+                        data = Decompress(data);
+                    }
+
+                    var fileNameOut = Settings.P_Client + info.FileName;
+                    var dirName = Path.GetDirectoryName(fileNameOut);
+                    if (!Directory.Exists(dirName))
+                        Directory.CreateDirectory(dirName);
+
+                    File.WriteAllBytes(fileNameOut, data);
+                    File.SetLastWriteTime(fileNameOut, info.Creation);
                 }
             }
-            catch
+            catch (HttpRequestException e)
             {
-                MessageBox.Show(string.Format("Failed to download file: {0}", fileName));
+                File.AppendAllText(@".\Error.txt",
+                                       $"[{DateTime.Now}] {info.FileName} could not be downloaded. ({e.Message}) {Environment.NewLine}");
+                ErrorFound = true;
             }
+            finally
+            {
+                if (ErrorFound)
+                {
+                    MessageBox.Show(string.Format("Failed to download file: {0}", fileName));
+                }
+            }
+
+            BeginDownload();
         }
 
         public byte[] Download(string fileName)
         {
-            string authInfo = Settings.P_Login + ":" + Settings.P_Password;
-            authInfo = Convert.ToBase64String(System.Text.Encoding.Default.GetBytes(authInfo));
-
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(Settings.P_Host + Path.ChangeExtension(fileName, ".gz"));
-            request.Method = "GET";
-            request.Accept = "application/json; charset=utf-8";
-
-            if (Settings.P_NeedLogin)
-                request.Headers["Authorization"] = "Basic " + authInfo;
-
-            var response = (HttpWebResponse)request.GetResponse();
-
-            MemoryStream ms = new MemoryStream();
-            response.GetResponseStream().CopyTo(ms);
-
-            byte[] data = ms.ToArray();
-
-            return data;
-        }
-
-        //Seems to want to cache the PList when using WebClient, so causes issues. No longer used.
-        public byte[] DownloadOld(string fileName)
-        {
-            fileName = fileName.Replace(@"\", "/");
-
-            if (fileName != "PList.gz")
-                fileName += Path.GetExtension(fileName);
-
-            try
+            using (HttpClient client = new())
             {
-                using WebClient client = new WebClient();
-
-                client.CachePolicy = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.NoCacheNoStore);
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.AcceptCharset.Clear();
+                client.DefaultRequestHeaders.AcceptCharset.Add(new StringWithQualityHeaderValue("utf-8"));
 
                 if (Settings.P_NeedLogin)
                 {
-                    client.Credentials = new NetworkCredential(Settings.P_Login, Settings.P_Password);
-                }
-                else
-                {
-                    client.Credentials = new NetworkCredential("", "");
+                    string authInfo = Settings.P_Login + ":" + Settings.P_Password;
+                    authInfo = Convert.ToBase64String(System.Text.Encoding.Default.GetBytes(authInfo));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authInfo);
                 }
 
-                var rand = new Random(1000).Next();
+                var task = Task.Run(() => client
+                    .GetAsync(new Uri(Settings.P_Host + Path.ChangeExtension(fileName, ".gz")), HttpCompletionOption.ResponseHeadersRead));
 
-                return client.DownloadData(Settings.P_Host + Path.ChangeExtension(fileName, ".gz") + $"?rand={rand}");
-            }
-            catch
-            {
-                return null;
+                var response = task.Result;
+
+                using Stream sm = response.Content.ReadAsStream();
+                using MemoryStream ms = new();
+                sm.CopyTo(ms);
+                byte[] data = ms.ToArray();
+                return data;
             }
         }
 
@@ -500,7 +485,7 @@ namespace Launcher
 
         private void ProgressCurrent_pb_SizeChanged(object sender, EventArgs e)
         {
-            ProgEnd_pb.Location = new Point((ProgressCurrent_pb.Location.X + ProgressCurrent_pb.Width), ProgressCurrent_pb.Location.Y);
+            ProgEnd_pb.Location = new Point((ProgressCurrent_pb.Location.X + ProgressCurrent_pb.Width), 490);
             if (ProgressCurrent_pb.Width == 0) ProgEnd_pb.Visible = false;
             else ProgEnd_pb.Visible = true;
         }
@@ -534,7 +519,7 @@ namespace Launcher
 
         private void TotalProg_pb_SizeChanged(object sender, EventArgs e)
         {
-            ProgTotalEnd_pb.Location = new Point((TotalProg_pb.Location.X + TotalProg_pb.Width), TotalProg_pb.Location.Y);
+            ProgTotalEnd_pb.Location = new Point((TotalProg_pb.Location.X + TotalProg_pb.Width), 508);
             if (TotalProg_pb.Width == 0) ProgTotalEnd_pb.Visible = false;
             else ProgTotalEnd_pb.Visible = true;
         }
@@ -545,7 +530,7 @@ namespace Launcher
             {
                 if (Completed)
                 {
-                    
+
                     ActionLabel.Text = "";
                     CurrentFile_label.Text = "Up to date.";
                     SpeedLabel.Text = "";
@@ -583,7 +568,7 @@ namespace Launcher
                     return;
                 }
 
-                var currentBytes = 0l;
+                var currentBytes = 0L;
                 FileInformation currentFile = null;
 
                 // Remove completed downloads..
@@ -608,7 +593,7 @@ namespace Launcher
                 if (Settings.P_Concurrency == 1)
                 {
                     // Note: Just mimic old behaviour for now until a better UI is done.
-                    if  (ActiveDownloads.Count > 0)
+                    if (ActiveDownloads.Count > 0)
                         currentFile = ActiveDownloads[0].Info;
                 }
 
@@ -619,9 +604,7 @@ namespace Launcher
                 TotalPercent_label.Visible = true;
 
                 if (LabelSwitch) ActionLabel.Text = string.Format("{0} Files Remaining", _fileCount - _currentCount);
-                else ActionLabel.Text = string.Format("{0:#,##0}MB Remaining",  ((_totalBytes) - (_completedBytes + currentBytes)) / 1024 / 1024);
-
-                //ActionLabel.Text = string.Format("{0:#,##0}MB / {1:#,##0}MB", (_completedBytes + _currentBytes) / 1024 / 1024, _totalBytes / 1024 / 1024);
+                else ActionLabel.Text = string.Format("{0:#,##0}MB Remaining", ((_totalBytes) - (_completedBytes + currentBytes)) / 1024 / 1024);
 
                 if (Settings.P_Concurrency > 1)
                 {
@@ -632,22 +615,23 @@ namespace Launcher
                 {
                     if (currentFile != null)
                     {
-                        //FileLabel.Text = string.Format("{0}, ({1:#,##0} MB) / ({2:#,##0} MB)", currentFile.FileName, _currentBytes / 1024 / 1024, currentFile.Compressed / 1024 / 1024);
                         CurrentFile_label.Text = string.Format("{0}", currentFile.FileName);
                         SpeedLabel.Text = ToSize(currentBytes / _stopwatch.Elapsed.TotalSeconds);
                         CurrentPercent_label.Text = ((int)(100 * currentBytes / currentFile.Length)).ToString() + "%";
                         ProgressCurrent_pb.Width = (int)(5.5 * (100 * currentBytes / currentFile.Length));
                     }
                 }
+
                 if (!(_completedBytes is 0 && currentBytes is 0 && _totalBytes is 0))
                 {
                     TotalProg_pb.Width = (int)(5.5 * (100 * (_completedBytes + currentBytes) / _totalBytes));
                     TotalPercent_label.Text = ((int)(100 * (_completedBytes + currentBytes) / _totalBytes)).ToString() + "%";
                 }
+
             }
-            catch (Exception ex)
+            catch
             {
-                
+                //to-do 
             }
 
         }
@@ -670,7 +654,11 @@ namespace Launcher
 
         private void AMain_FormClosed(object sender, FormClosedEventArgs e)
         {
-            MoveOldFilesToCurrent();
+                MoveOldFilesToCurrent();
+
+                Launch_pb?.Dispose();
+                Close_pb?.Dispose();
+                Environment.Exit(0);
         }
 
         private static string[] suffixes = new[] { " B", " KB", " MB", " GB", " TB", " PB" };
@@ -720,5 +708,5 @@ namespace Launcher
                     File.Move(oldFilename, originalFilename);
             }
         }
-    }
+    } 
 }


### PR DESCRIPTION
Client main thread hanging fix.  Occassional issue with dispose() exeption thrown by other thread but checked and no memory leak.  Once AMain.cs disposing correctly in +=FormClosed handler then Environment.Exit(0) is now called which fixes the hang.