### PR TITLE
Multiple Issue fix + Guild QOL (#714)

### DIFF
--- a/Client/MirObjects/PlayerObject.cs
+++ b/Client/MirObjects/PlayerObject.cs
@@ -181,7 +181,14 @@ namespace Client.MirObjects
 
         public override bool ShouldDrawHealth()
         {
-            return this == User && (GroupDialog.GroupList.Contains(Name) || GroupDialog.GroupList.Count == 0);
+            if (GroupDialog.GroupList.Contains(Name) || this == User)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public void ProcessBuffs()

--- a/Client/MirObjects/UserObject.cs
+++ b/Client/MirObjects/UserObject.cs
@@ -388,7 +388,6 @@ namespace Client.MirObjects
                         break;
                     case ItemSet.RedOrchid:
                         Stats[Stat.Accuracy] += 2;
-                        Stats[Stat.HPDrainRatePercent] += 10;
                         break;
                     case ItemSet.RedFlower:
                         Stats[Stat.HP] += 50;

--- a/Client/MirScenes/LoginScene.cs
+++ b/Client/MirScenes/LoginScene.cs
@@ -48,6 +48,7 @@ namespace Client.MirScenes
                     _account = new NewAccountDialog { Parent = _background };
                     _account.Disposing += (o1, e1) => _login.Show();
                 };
+
             _login.PassButton.Click += (o, e) =>
                 {
                     OpenPasswordChangeDialog(string.Empty, string.Empty);                    
@@ -79,30 +80,6 @@ namespace Client.MirScenes
                 Location = new Point(Settings.ScreenWidth - 116, 10),
                 Visible = Settings.UseTestConfig
             };
-
-            //ViolenceLabel = new MirImageControl
-            //{
-            //    Index = 89,
-            //    Library = Libraries.Prguse,
-            //    Parent = this,
-            //    Location = new Point(471, 10)
-            //};
-
-            //MinorLabel = new MirImageControl
-            //{
-            //    Index = 87,
-            //    Library = Libraries.Prguse,
-            //    Parent = this,
-            //    Location = new Point(578, 10)
-            //};
-
-            //YouthLabel = new MirImageControl
-            //{
-            //    Index = 88,
-            //    Library = Libraries.Prguse,
-            //    Parent = this,
-            //    Location = new Point(684, 10)
-            //};
 
             _connectBox = new MirMessageBox("Attempting to connect to the server.", MirMessageBoxButtons.Cancel);
             _connectBox.CancelButton.Click += (o, e) => Program.Form.Close();
@@ -821,21 +798,6 @@ namespace Client.MirScenes
                 };
                 OKButton.Click += (o, e) => CreateAccount();
 
-
-                AccountIDTextBox = new MirTextBox
-                {
-                    Border = true,
-                    BorderColour = Color.Gray,
-                    Location = new Point(226, 103),
-                    MaxLength = Globals.MaxAccountIDLength,
-                    Parent = this,
-                    Size = new Size(136, 18),
-                };
-                AccountIDTextBox.SetFocus();
-                AccountIDTextBox.TextBox.MaxLength = Globals.MaxAccountIDLength;
-                AccountIDTextBox.TextBox.TextChanged += AccountIDTextBox_TextChanged;
-                AccountIDTextBox.TextBox.GotFocus += AccountIDTextBox_GotFocus;
-
                 Password1TextBox = new MirTextBox
                 {
                     Border = true,
@@ -940,7 +902,20 @@ namespace Client.MirScenes
                     Size = new Size(300, 70),
                     Visible = false
                 };
-                
+
+                AccountIDTextBox = new MirTextBox
+                {
+                    Border = true,
+                    BorderColour = Color.Gray,
+                    Location = new Point(226, 103),
+                    MaxLength = Globals.MaxAccountIDLength,
+                    Parent = this,
+                    Size = new Size(136, 18),
+                };
+
+                AccountIDTextBox.TextBox.MaxLength = Globals.MaxAccountIDLength;
+                AccountIDTextBox.TextBox.TextChanged += AccountIDTextBox_TextChanged;
+                AccountIDTextBox.TextBox.GotFocus += AccountIDTextBox_GotFocus;
             }
 
 

--- a/Server/MirDatabase/GuildInfo.cs
+++ b/Server/MirDatabase/GuildInfo.cs
@@ -55,10 +55,9 @@ namespace Server.MirDatabase
 
             if (Name == Settings.NewbieGuild)
             {
-                MemberCap = 1000;
+                MemberCap = Settings.NewbieGuildMaxSize;
                 Level = 1;
             }
-
             else if(Level < Settings.Guild_MembercapList.Count)
             {
                 MemberCap = Settings.Guild_MembercapList[Level];
@@ -150,7 +149,11 @@ namespace Server.MirDatabase
                 MaxExperience = Settings.Guild_ExperienceList[Level];
             }
 
-            if (Level < Settings.Guild_MembercapList.Count)
+            if (Name == Settings.NewbieGuild)
+            {
+                MemberCap = Settings.NewbieGuildMaxSize;
+            }
+            else if (Level < Settings.Guild_MembercapList.Count)
             {
                 MemberCap = Settings.Guild_MembercapList[Level];
             }

--- a/Server/MirObjects/HeroObject.cs
+++ b/Server/MirObjects/HeroObject.cs
@@ -1097,9 +1097,16 @@ namespace Server.MirObjects
 
         public override void GainExp(uint amount)
         {
-            if (!CanGainExp) return;
-
             if (amount == 0) return;
+
+            for (int i = 0; i < Pets.Count; i++)
+            {
+                MonsterObject monster = Pets[i];
+                if (monster.CurrentMap == CurrentMap && Functions.InRange(monster.CurrentLocation, CurrentLocation, Globals.DataRange) && !monster.Dead)
+                    monster.PetExp(amount);
+            }
+
+            if (!CanGainExp) return;
 
             if (Stats[Stat.ExpRatePercent] > 0)
             {
@@ -1109,13 +1116,6 @@ namespace Server.MirObjects
             Experience += amount;
 
             Owner.Enqueue(new S.GainHeroExperience { Amount = amount });
-
-            for (int i = 0; i < Pets.Count; i++)
-            {
-                MonsterObject monster = Pets[i];
-                if (monster.CurrentMap == CurrentMap && Functions.InRange(monster.CurrentLocation, CurrentLocation, Globals.DataRange) && !monster.Dead)
-                    monster.PetExp(amount);
-            }
 
             if (Experience < MaxExperience) return;
             if (Level >= ushort.MaxValue) return;

--- a/Server/MirObjects/HumanObject.cs
+++ b/Server/MirObjects/HumanObject.cs
@@ -1973,7 +1973,6 @@ namespace Server.MirObjects
                         break;
                     case ItemSet.RedOrchid:
                         Stats[Stat.Accuracy] += 2;
-                        Stats[Stat.HPDrainRatePercent] += 10;
                         break;
                     case ItemSet.RedFlower:
                         Stats[Stat.HP] += 50;
@@ -2952,11 +2951,11 @@ namespace Server.MirObjects
 
                 if (magic != null)
                 {
-                    if (FatalSword)
-                        damageBase = magic.GetDamage(damageBase);
-
                     if (!FatalSword && Envir.Random.Next(10) == 0)
                         FatalSword = true;
+
+                    if (FatalSword)
+                        damageBase = magic.GetDamage(damageBase);
                 }
                 #endregion
 

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -114,7 +114,8 @@ namespace Server
         public static int RestedPeriod = 60,
                           RestedBuffLength = 10,
                           RestedExpBonus = 5,
-                          RestedMaxBonus = 24;
+                          RestedMaxBonus = 24,
+                          NewbieGuildMaxSize = 1000;
 
         public static string NewbieGuild = "NewbieGuild",
                              SkeletonName = "BoneFamiliar",
@@ -380,6 +381,7 @@ namespace Server
             PetSave = Reader.ReadBoolean("Game", "PetSave", PetSave);
             PKDelay = Reader.ReadInt32("Game", "PKDelay", PKDelay);
             NewbieGuild = Reader.ReadString("Game", "NewbieGuild", NewbieGuild);
+            NewbieGuildMaxSize = Reader.ReadInt32("Game", "NewbieGuildMaxSize", NewbieGuildMaxSize);
             SkeletonName = Reader.ReadString("Game", "SkeletonName", SkeletonName);
             BugBatName = Reader.ReadString("Game", "BugBatName", BugBatName);
             ShinsuName = Reader.ReadString("Game", "ShinsuName", ShinsuName);
@@ -642,6 +644,7 @@ namespace Server
             Reader.Write("Game", "PetSave", PetSave);
             Reader.Write("Game", "PKDelay", PKDelay);
             Reader.Write("Game", "NewbieGuild", NewbieGuild);
+            Reader.Write("Game", "NewbieGuildMaxSize", NewbieGuildMaxSize);
             Reader.Write("Game", "SkeletonName", SkeletonName);
             Reader.Write("Game", "BugBatName", BugBatName);
             Reader.Write("Game", "ShinsuName", ShinsuName);


### PR DESCRIPTION
* Account text id field now has initial focus

* HP drain removed from Red Orchid set.  Individual items should give 5% each.

* Pet exp gain now calculated before hero to avoid issue where max level character cannot level pets.

* fix issue where health bar wouldn't show for group members.

* Fix FatalSword logic to run proc'ing skill chance before calculating dmg if proc'd

* Added NewbieGuildMaxSize to 'Game' settings. Defaults to 1000. Disabled NewbieGuild from gaining exp.
Disabled non-admin account from creating newbie guild (case insensitive comparison) Admin accounts no longer need required items to make a guild.