### PR TITLE
Issue-644

### DIFF
--- a/Server/MirEnvir/Map.cs
+++ b/Server/MirEnvir/Map.cs
@@ -1859,7 +1859,7 @@ namespace Server.MirEnvir
                                         //Only targets
                                         if (target.IsAttackTarget(player))
                                         {
-                                            target.ApplyPoison(new Poison { PType = PoisonType.Slow, Duration = value, TickSpeed = 1000, Value = value2 }, player);
+                                            target.ApplyPoison(new Poison { PType = PoisonType.Slow, Duration = value, TickSpeed = 1000, Value = value2, Owner = player }, player);
 
                                             var stats = new Stats
                                             {


### PR DESCRIPTION
Curse now causes attacking player to go brown.
Poison action was not being assigned an owner for browntime calculation.