### PR TITLE
issue 695

### DIFF
--- a/Client/Forms/CMain.cs
+++ b/Client/Forms/CMain.cs
@@ -42,7 +42,7 @@ namespace Client
         public static long PingTime;
         public static long NextPing = 10000;
 
-        public static bool Shift, Alt, Ctrl, Tilde;
+        public static bool Shift, Alt, Ctrl, Tilde, SpellTargetLock;
         public static double BytesSent, BytesReceived;
 
         public static KeyBindSettings InputKeys = new KeyBindSettings();
@@ -125,6 +125,7 @@ namespace Client
             Alt = false;
             Ctrl = false;
             Tilde = false;
+            SpellTargetLock = false;
         }
 
         public static void CMain_KeyDown(object sender, KeyEventArgs e)
@@ -132,6 +133,16 @@ namespace Client
             Shift = e.Shift;
             Alt = e.Alt;
             Ctrl = e.Control;
+
+            if (!String.IsNullOrEmpty(InputKeys.GetKey(KeybindOptions.TargetSpellLockOn)))
+            {
+                SpellTargetLock = e.KeyCode == (Keys)Enum.Parse(typeof(Keys), InputKeys.GetKey(KeybindOptions.TargetSpellLockOn), true);
+            }
+            else
+            {
+                SpellTargetLock = false;
+            }
+
 
             if (e.KeyCode == Keys.Oem8)
                 CMain.Tilde = true;
@@ -175,6 +186,15 @@ namespace Client
             Shift = e.Shift;
             Alt = e.Alt;
             Ctrl = e.Control;
+
+            if (!String.IsNullOrEmpty(InputKeys.GetKey(KeybindOptions.TargetSpellLockOn)))
+            {
+                SpellTargetLock = e.KeyCode == (Keys)Enum.Parse(typeof(Keys), InputKeys.GetKey(KeybindOptions.TargetSpellLockOn), true);
+            }
+            else
+            {
+                SpellTargetLock = false;
+            }
 
             if (e.KeyCode == Keys.Oem8)
                 CMain.Tilde = false;

--- a/Client/KeyBindSettings.cs
+++ b/Client/KeyBindSettings.cs
@@ -98,7 +98,8 @@
         HeroSkill8,
         HeroInventory,
         HeroEquipment,
-        HeroSkills
+        HeroSkills,
+        TargetSpellLockOn
     }
 
     public class KeyBind
@@ -130,7 +131,7 @@
 
             if (!File.Exists(@".\KeyBinds.ini"))
             {
-                Save();
+                Save(DefaultKeylist);
                 return;
             }
 
@@ -151,7 +152,7 @@
             }
         }
 
-        public void Save()
+        public void Save(List<KeyBind> keyList)
         {
             Reader.Write("Guide", "01", "RequireAlt,RequireShift,RequireTilde,RequireCtrl");
             Reader.Write("Guide", "02", "have 3 options: 0/1/2");
@@ -165,7 +166,7 @@
             Reader.Write("Guide", "10", "To get the value for RequireKey look at:");
             Reader.Write("Guide", "11", "https://msdn.microsoft.com/en-us/library/system.windows.forms.keys(v=vs.110).aspx");
         
-            foreach (KeyBind Inputkey in Keylist)
+            foreach (KeyBind Inputkey in keyList)
             {
                 Reader.Write(Inputkey.function.ToString(), "RequireAlt", Inputkey.RequireAlt);
                 Reader.Write(Inputkey.function.ToString(), "RequireShift", Inputkey.RequireShift);
@@ -371,6 +372,8 @@
             InputKey = new KeyBind { Group = "Toggle", Description = "Take Screenshot", function = KeybindOptions.Screenshot, RequireAlt = 2, RequireShift = 2, RequireTilde = 2, RequireCtrl = 2, Key = Keys.PrintScreen };
             list.Add(InputKey);
             InputKey = new KeyBind { Group = "Toggle", Description = "Toggle Dropview", function = KeybindOptions.DropView, RequireAlt = 2, RequireShift = 2, RequireTilde = 2, RequireCtrl = 2, Key = Keys.Tab };
+            list.Add(InputKey);
+            InputKey = new KeyBind { Group = "Combat", Description = "Hold to enable target spell lock-on", function = KeybindOptions.TargetSpellLockOn, RequireAlt = 2, RequireShift = 2, RequireTilde = 2, RequireCtrl = 2, Key = Keys.None };
             list.Add(InputKey);
         }
 

--- a/Client/MirScenes/Dialogs/HelpDialog.cs
+++ b/Client/MirScenes/Dialogs/HelpDialog.cs
@@ -199,25 +199,28 @@ namespace Client.MirScenes.Dialogs
     {
         public ShortcutPage1()
         {
-            Shortcuts = new List<ShortcutInfo>();
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Exit), "Exit the game"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Logout), "Log out"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Bar1Skill1) + "-" + CMain.InputKeys.GetKey(KeybindOptions.Bar1Skill8), "Skill buttons"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Inventory), "Inventory window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Equipment), "Status window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Skills), "Skill window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Group), "Group window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Trade), "Trade window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Friends), "Friend window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Minimap), "Minimap window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Guilds), "Guild window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.GameShop), "Gameshop window (open / close)"));
-            //Shortcuts.Add(new ShortcutInfo("K", "Rental window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Relationship), "Engagement window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Belt), "Belt window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Options), "Option window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Help), "Help window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Mount), "Mount / Dismount ride"));
+            Shortcuts = new List<ShortcutInfo>
+            {
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Exit), "Exit the game"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Logout), "Log out"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Bar1Skill1) + "-" + CMain.InputKeys.GetKey(KeybindOptions.Bar1Skill8), "Skill buttons"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Inventory), "Inventory window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Equipment), "Status window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Skills), "Skill window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Group), "Group window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Trade), "Trade window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Friends), "Friend window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Minimap), "Minimap window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Guilds), "Guild window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.GameShop), "Gameshop window (open / close)"),
+                //Shortcuts.Add(new ShortcutInfo("K", "Rental window (open / close)"));
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Relationship), "Engagement window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Belt), "Belt window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Options), "Option window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Help), "Help window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Mount), "Mount / Dismount ride"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.TargetSpellLockOn), "Lock spell onto target not cursor location")
+            };
 
             LoadKeyBinds();
         }
@@ -226,27 +229,29 @@ namespace Client.MirScenes.Dialogs
     {
         public ShortcutPage2()
         {
-            Shortcuts = new List<ShortcutInfo>();
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.ChangePetmode), "Toggle pet attack pet"));
-            //Shortcuts.Add(new ShortcutInfo("Ctrl + F", "Change the font in the chat box"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.ChangeAttackmode), "Toggle player attack mode"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodePeace), "Peace Mode - Attack monsters only"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeGroup), "Group Mode - Attack all subjects except your group members"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeGuild), "Guild Mode - Attack all subjects except your guild members"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeRedbrown), "Good/Evil Mode - Attack PK players and monsters only"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeAll), "All Attack Mode - Attack all subjects"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Bigmap), "Show the field map"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Skillbar), "Show the skill bar"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Autorun), "Auto run on / off"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Cameramode), "Show / Hide interface"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Pickup), "Highlight / Pickup Items"));
-            Shortcuts.Add(new ShortcutInfo("Ctrl + Right Click", "Show other players kits"));
-            //Shortcuts.Add(new ShortcutInfo("F12", "Chat macros"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Screenshot), "Screen Capture"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Fishing), "Open / Close fishing window"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Mentor), "Mentor window (open / close)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.CreaturePickup), "Creature Pickup (Multi Mouse Target)"));
-            Shortcuts.Add(new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.CreatureAutoPickup), "Creature Pickup (Single Mouse Target)"));
+            Shortcuts = new List<ShortcutInfo>
+            {
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.ChangePetmode), "Toggle pet attack pet"),
+                //Shortcuts.Add(new ShortcutInfo("Ctrl + F", "Change the font in the chat box"));
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.ChangeAttackmode), "Toggle player attack mode"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodePeace), "Peace Mode - Attack monsters only"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeGroup), "Group Mode - Attack all subjects except your group members"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeGuild), "Guild Mode - Attack all subjects except your guild members"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeRedbrown), "Good/Evil Mode - Attack PK players and monsters only"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.AttackmodeAll), "All Attack Mode - Attack all subjects"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Bigmap), "Show the field map"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Skillbar), "Show the skill bar"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Autorun), "Auto run on / off"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Cameramode), "Show / Hide interface"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Pickup), "Highlight / Pickup Items"),
+                new ShortcutInfo("Ctrl + Right Click", "Show other players kits"),
+                //Shortcuts.Add(new ShortcutInfo("F12", "Chat macros"));
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Screenshot), "Screen Capture"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Fishing), "Open / Close fishing window"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.Mentor), "Mentor window (open / close)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.CreaturePickup), "Creature Pickup (Multi Mouse Target)"),
+                new ShortcutInfo(CMain.InputKeys.GetKey(KeybindOptions.CreatureAutoPickup), "Creature Pickup (Single Mouse Target)")
+            };
 
             LoadKeyBinds();
         }
@@ -255,11 +260,13 @@ namespace Client.MirScenes.Dialogs
     {
         public ShortcutPage3()
         {
-            Shortcuts = new List<ShortcutInfo>();
-            //Shortcuts.Add(new ShortcutInfo("` / Ctrl", "Change the skill bar"));
-            Shortcuts.Add(new ShortcutInfo("/(username)", "Command to whisper to others"));
-            Shortcuts.Add(new ShortcutInfo("!(text)", "Command to shout to others nearby"));
-            Shortcuts.Add(new ShortcutInfo("!~(text)", "Command to guild chat"));
+            Shortcuts = new List<ShortcutInfo>
+            {
+                //Shortcuts.Add(new ShortcutInfo("` / Ctrl", "Change the skill bar"));
+                new ShortcutInfo("/(username)", "Command to whisper to others"),
+                new ShortcutInfo("!(text)", "Command to shout to others nearby"),
+                new ShortcutInfo("!~(text)", "Command to guild chat")
+            };
 
             LoadKeyBinds();
         }

--- a/Client/MirScenes/Dialogs/KeyboardLayoutDialog.cs
+++ b/Client/MirScenes/Dialogs/KeyboardLayoutDialog.cs
@@ -60,7 +60,12 @@ namespace Client.MirScenes.Dialogs
                 PressedIndex = 362,
                 Sound = SoundList.ButtonA,
             };
-            CloseButton.Click += (o, e) => Hide();
+
+            CloseButton.Click += (o, e) =>
+            {
+                CMain.InputKeys.Save(CMain.InputKeys.Keylist);
+                Hide();
+            };
 
             ScrollUpButton = new MirButton
             {

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -9,7 +9,6 @@ using Font = System.Drawing.Font;
 using S = ServerPackets;
 using C = ClientPackets;
 using Effect = Client.MirObjects.Effect;
-
 using Client.MirScenes.Dialogs;
 using Client.Utils;
 
@@ -11943,7 +11942,7 @@ namespace Client.MirScenes
             }
             else
             {
-                Network.Enqueue(new C.Magic { ObjectID = actor.ObjectID, Spell = magic.Spell, Direction = dir, TargetID = targetID, Location = location });
+                Network.Enqueue(new C.Magic { ObjectID = actor.ObjectID, Spell = magic.Spell, Direction = dir, TargetID = targetID, Location = location, SpellTargetLock = CMain.SpellTargetLock });
             }
         }
 

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -46,7 +46,6 @@ namespace Client
                 else Application.Run(Form = new CMain());
 
                 Settings.Save();
-                CMain.InputKeys.Save();
 
                 if (Restart)
                 {

--- a/Server/MirNetwork/MirConnection.cs
+++ b/Server/MirNetwork/MirConnection.cs
@@ -1365,7 +1365,7 @@ namespace Server.MirNetwork
             if (!actor.Dead && (actor.ActionTime > Envir.Time || actor.SpellTime > Envir.Time))
                 _retryList.Enqueue(p);
             else
-                actor.BeginMagic(p.Spell, p.Direction, p.TargetID, p.Location);
+                actor.BeginMagic(p.Spell, p.Direction, p.TargetID, p.Location, p.SpellTargetLock);
         }
 
         private void SwitchGroup(C.SwitchGroup p)

--- a/Server/MirObjects/HeroObject.cs
+++ b/Server/MirObjects/HeroObject.cs
@@ -293,7 +293,7 @@ namespace Server.MirObjects
         {
             return true;
         }
-        public override void BeginMagic(Spell spell, MirDirection dir, uint targetID, Point location)
+        public override void BeginMagic(Spell spell, MirDirection dir, uint targetID, Point location, bool spellTargetLock = false)
         {
             NextMagicSpell = spell;
             NextMagicDirection = dir;

--- a/Server/MirObjects/HumanObject.cs
+++ b/Server/MirObjects/HumanObject.cs
@@ -3249,9 +3249,9 @@ namespace Server.MirObjects
         {
             return !Dead && Envir.Time >= ActionTime || Envir.Time >= SpellTime;
         }
-        public virtual void BeginMagic(Spell spell, MirDirection dir, uint targetID, Point location)
+        public virtual void BeginMagic(Spell spell, MirDirection dir, uint targetID, Point location, Boolean spellTargetLock = false)
         {
-            Magic(spell, dir, targetID, location);
+            Magic(spell, dir, targetID, location, spellTargetLock);
         }
 
         public int MagicCost(UserMagic magic)
@@ -3279,7 +3279,7 @@ namespace Server.MirObjects
             return cost;
         }
         public virtual MapObject DefaultMagicTarget => this;
-        public void Magic(Spell spell, MirDirection dir, uint targetID, Point location)
+        public void Magic(Spell spell, MirDirection dir, uint targetID, Point location, bool spellTargetLock = false)
         {
             if (!CanCast)
             {
@@ -3414,17 +3414,17 @@ namespace Server.MirObjects
                     break;
                 case Spell.FireBang:
                 case Spell.IceStorm:
-                    FireBang(magic, target == null ? location : target.CurrentLocation);
+                    FireBang(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location);
                     break;
                 case Spell.MassHiding:
-                    MassHiding(magic, target == null ? location : target.CurrentLocation, out cast);
+                    MassHiding(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.SoulShield:
                 case Spell.BlessedArmour:
-                    SoulShield(magic, target == null ? location : target.CurrentLocation, out cast);
+                    SoulShield(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.FireWall:
-                    FireWall(magic, target == null ? location : target.CurrentLocation);
+                    FireWall(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location);
                     break;
                 case Spell.Lightning:
                     Lightning(magic);
@@ -3433,7 +3433,7 @@ namespace Server.MirObjects
                     HeavenlySword(magic);
                     break;
                 case Spell.MassHealing:
-                    MassHealing(magic, target == null ? location : target.CurrentLocation);
+                    MassHealing(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location);
                     break;
                 case Spell.ShoulderDash:
                     ShoulderDash(magic);
@@ -3500,15 +3500,14 @@ namespace Server.MirObjects
                     Mirroring(magic);
                     break;
                 case Spell.Blizzard:
-                    Blizzard(magic, target == null ? location : target.CurrentLocation, out cast);
+                    Blizzard(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.MeteorStrike:
-                    MeteorStrike(magic, target == null ? location : target.CurrentLocation, out cast);
+                    MeteorStrike(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.IceThrust:
                     IceThrust(magic);
                     break;
-
                 case Spell.ProtectionField:
                     ProtectionField(magic);
                     break;
@@ -3516,14 +3515,14 @@ namespace Server.MirObjects
                     PetEnhancer(target, magic, out cast);
                     break;
                 case Spell.TrapHexagon:
-                    TrapHexagon(magic, target == null ? location : target.CurrentLocation, out cast);
+                    TrapHexagon(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.Reincarnation:
                     if (!CurrentMap.Info.NoReincarnation)
                         Reincarnation(magic, target == null ? null : target as PlayerObject, out cast);
                     break;
                 case Spell.Curse:
-                    Curse(magic, target == null ? location : target.CurrentLocation, out cast);
+                    Curse(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.SummonHolyDeva:
                     SummonHolyDeva(magic);
@@ -3538,7 +3537,7 @@ namespace Server.MirObjects
                     UltimateEnhancer(target, magic, out cast);
                     break;
                 case Spell.Plague:
-                    Plague(magic, target == null ? location : target.CurrentLocation, out cast);
+                    Plague(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.SwiftFeet:
                     SwiftFeet(magic, out cast);
@@ -3597,7 +3596,7 @@ namespace Server.MirObjects
                     ArcherSummon(magic, target, location);
                     break;
                 case Spell.Stonetrap:
-                    ArcherSummonStone(magic, target == null ? location : target.CurrentLocation, out cast);
+                    ArcherSummonStone(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location, out cast);
                     break;
                 case Spell.VampireShot:
                 case Spell.PoisonShot:
@@ -3614,7 +3613,7 @@ namespace Server.MirObjects
                     MoonMist(magic);
                     break;
                 case Spell.HealingCircle:
-                    HealingCircle(magic, target == null ? location : target.CurrentLocation);
+                    HealingCircle(magic, spellTargetLock ? (target != null ? target.CurrentLocation : location) : location);
                     break;
 
                 //Custom Spells

--- a/Shared/ClientPackets.cs
+++ b/Shared/ClientPackets.cs
@@ -1012,6 +1012,7 @@ namespace ClientPackets
         public uint TargetID;
         public Point Location;
         public uint ObjectID;
+        public bool SpellTargetLock;
 
         protected override void ReadPacket(BinaryReader reader)
         {
@@ -1020,6 +1021,7 @@ namespace ClientPackets
             Direction = (MirDirection)reader.ReadByte();
             TargetID = reader.ReadUInt32();
             Location = new Point(reader.ReadInt32(), reader.ReadInt32());
+            SpellTargetLock = reader.ReadBoolean();
         }
         protected override void WritePacket(BinaryWriter writer)
         {
@@ -1029,6 +1031,7 @@ namespace ClientPackets
             writer.Write(TargetID);
             writer.Write(Location.X);
             writer.Write(Location.Y);
+            writer.Write(SpellTargetLock);
         }
     }
 


### PR DESCRIPTION
Added setting in keybinds under 'Combat'. This setting when held down will use target location rather than cursor for following spells:

Firebang
MassHiding
SoulShield
Firewall
MassHealing
Blizzard
MeteorStrike
TrapHexagon
Plague
ArcherSummonStone
HealingCircle

Changing a setting in keybind screen now saves to Keybinds.ini - previously did not save to file.