### PR TITLE
Issue 642

### DIFF
--- a/Server/MirObjects/ConquestObject.cs
+++ b/Server/MirObjects/ConquestObject.cs
@@ -591,6 +591,12 @@ namespace Server.MirObjects
                     Guild.Conquest = this;
                     break;
                 case ConquestGame.ControlPoints:
+
+                    if (Guild != null)
+                    {
+                        tmpPrevious = Guild;
+                    }
+
                     GuildInfo.Owner = winningGuild.Guildindex;
                     Guild = winningGuild;
                     Guild.Conquest = this;
@@ -612,10 +618,15 @@ namespace Server.MirObjects
                 FlagList[i].UpdateColour();
             }
 
-            if (Guild != null)
+            if (Guild != null &&
+                (tmpPrevious == null || Guild != tmpPrevious))
             {
                 UpdatePlayers(Guild);
-                if (tmpPrevious != null) UpdatePlayers(tmpPrevious);
+                if (tmpPrevious != null)
+                {
+                    tmpPrevious.Conquest = null;
+                    UpdatePlayers(tmpPrevious);
+                }
                 GuildInfo.NeedSave = true;
             }
         }

--- a/Server/MirObjects/GuildObject.cs
+++ b/Server/MirObjects/GuildObject.cs
@@ -153,11 +153,19 @@ namespace Server.MirObjects
         public void SendGuildStatus(PlayerObject member)
         {
             string gName = Name;
+            string conquest = "[" + Conquest.Info.Name + "]";
 
             if (Conquest != null)
             {
-                string conquest = "[" + Conquest.Info.Name + "]";
                 gName += conquest;
+            }
+            else
+            {
+                // remove conquest name if it exists
+                if (gName.EndsWith(conquest))
+                {
+                    gName = gName.Replace(conquest, String.Empty);
+                }
             }
 
             member.Enqueue(new ServerPackets.GuildStatus()

--- a/Server/MirObjects/GuildObject.cs
+++ b/Server/MirObjects/GuildObject.cs
@@ -153,19 +153,10 @@ namespace Server.MirObjects
         public void SendGuildStatus(PlayerObject member)
         {
             string gName = Name;
-            string conquest = "[" + Conquest.Info.Name + "]";
 
             if (Conquest != null)
             {
-                gName += conquest;
-            }
-            else
-            {
-                // remove conquest name if it exists
-                if (gName.EndsWith(conquest))
-                {
-                    gName = gName.Replace(conquest, String.Empty);
-                }
+                gName += "[" + Conquest.Info.Name + "]";
             }
 
             member.Enqueue(new ServerPackets.GuildStatus()


### PR DESCRIPTION
- Fix ControlPoints mode where previous owner was not being set when changing hands.
- Fix logic in TakeConquest to unset previous owners as conquest holders.
- Added additional check when updating players name to remove conquest info from name title if  guild has no active conquest.