### PR TITLE
issue-758

### DIFF
--- a/Server.MirForms/Database/ItemInfoFormNew.cs
+++ b/Server.MirForms/Database/ItemInfoFormNew.cs
@@ -423,7 +423,8 @@ namespace Server.Database
         {
             var col = itemInfoGridView.Columns[e.ColumnIndex];
 
-            if (col.Name.Equals("Modified", comparisonType: StringComparison.CurrentCultureIgnoreCase))
+            if (col.Name.Equals("Modified", comparisonType: StringComparison.CurrentCultureIgnoreCase) ||
+                col.Name.Equals("ItemIndex", comparisonType: StringComparison.CurrentCultureIgnoreCase))
             {
                 return;
             }
@@ -933,7 +934,10 @@ namespace Server.Database
             if (itemInfoGridView.CurrentCell is DataGridViewComboBoxCell ||
                 itemInfoGridView.CurrentCell is DataGridViewCheckBoxCell)
             {
-                itemInfoGridView.Rows[e.RowIndex].Cells["Modified"].Value = true;
+                if (itemInfoGridView.Rows[e.RowIndex].DataBoundItem != null)
+                {
+                    itemInfoGridView.Rows[e.RowIndex].Cells["Modified"].Value = true;
+                }
             }
         }
 


### PR DESCRIPTION
- Fix issue with not being able to create new error. Logic around settings Modified to true threw index out of bounds exception.
- Fix issue (#759) where validation of fields was being executed against Index column causing user to never be able to exit this field without deleting new item row.