### PR TITLE
Various issues fixed (#775)

### DIFF
--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -897,7 +897,7 @@ namespace Client.MirObjects
                         switch (BaseImage)
                         {
                             case Monster.KingScorpion:
-                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.KingScorpion], 272 + (int)Direction * 8, 8, Frame.Count * Frame.Interval, this));
+                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.KingScorpion], 544 + (int)Direction * 8, 8, Frame.Count * Frame.Interval, this));
                                 break;
                             case Monster.DarkDevil:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DarkDevil], 272 + (int)Direction * 8, 8, Frame.Count * Frame.Interval, this));

--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -2865,6 +2865,20 @@ namespace Server.MirEnvir
             return MapList.SelectMany(t1 => t1.NPCs.Where(t => t.Info.GameName.StartsWith(name, StringComparison.CurrentCultureIgnoreCase) && t.Info.ShowOnBigMap)).FirstOrDefault();
         }
 
+        public MonsterInfo GetMonsterInfo(int id, bool strict = false)
+        {
+            String monsterName = MonsterInfoList.FirstOrDefault(x => x.Index == id)?.Name;
+
+            if (monsterName == null)
+            {
+                return null;
+            }
+            else
+            {
+                return (GetMonsterInfo(monsterName, strict));
+            }
+        }
+
         public MonsterInfo GetMonsterInfo(string name, bool Strict = false)
         {
             for (var i = 0; i < MonsterInfoList.Count; i++)

--- a/Server/MirObjects/HumanObject.cs
+++ b/Server/MirObjects/HumanObject.cs
@@ -964,23 +964,47 @@ namespace Server.MirObjects
             if (item.RentalInformation != null && item.RentalInformation.BindingFlags.HasFlag(BindMode.DontUpgrade))
                 return false;
 
+            string message = String.Empty;
+            ChatType chatType;
+
             if (item.AddedStats[Stat.Luck] > (Settings.MaxLuck * -1) && Envir.Random.Next(20) == 0)
             {
                 Stats[Stat.Luck]--;
                 item.AddedStats[Stat.Luck]--;
                 Enqueue(new S.RefreshItem { Item = item });
-                ReceiveChat(GameLanguage.WeaponCurse, ChatType.System);
+
+                message = GameLanguage.WeaponCurse;
+                chatType = ChatType.System;
+                
             }
             else if (item.AddedStats[Stat.Luck] <= 0 || Envir.Random.Next(10 * item.GetTotal(Stat.Luck)) == 0)
             {
                 Stats[Stat.Luck]++;
                 item.AddedStats[Stat.Luck]++;
                 Enqueue(new S.RefreshItem { Item = item });
-                ReceiveChat(GameLanguage.WeaponLuck, ChatType.Hint);
+
+                message = GameLanguage.WeaponLuck;
+                chatType = ChatType.Hint;
             }
             else
             {
-                ReceiveChat(GameLanguage.WeaponNoEffect, ChatType.Hint);
+                message = GameLanguage.WeaponNoEffect;
+                chatType = ChatType.Hint;
+            }
+
+            if (this is HeroObject hero)
+            {
+                if (message == GameLanguage.WeaponCurse ||
+                    message == GameLanguage.WeaponLuck)
+                {
+                    hero.Owner.Enqueue(new S.RefreshItem { Item = item });
+                }
+
+                hero.Owner.ReceiveChat($"[Hero: {hero.Name}] {message}", chatType);
+            }
+            else
+            {
+                ReceiveChat(message, chatType);
             }
 
             return true;
@@ -5948,7 +5972,7 @@ namespace Server.MirObjects
 
                 case Spell.Haste:
                     {
-                        AddBuff(BuffType.Haste, this, (Settings.Second * 30) + (magic.Level + 1), new Stats { [Stat.AttackSpeed] = (magic.Level + 1) * 2 });
+                        AddBuff(BuffType.Haste, this, (Settings.Second * 25) + (Settings.Second * magic.Level * 15), new Stats { [Stat.AttackSpeed] = (magic.Level * 2) + 2 });
                         LevelMagic(magic);
                     }
                     break;

--- a/Server/MirObjects/MapObject.cs
+++ b/Server/MirObjects/MapObject.cs
@@ -424,7 +424,6 @@ namespace Server.MirObjects
         {
             if (attacker == null || attacker.Node == null) return false;
             if (Dead || InSafeZone || attacker.InSafeZone || attacker == this) return false;
-            if (CurrentMap.Info.NoFight) return false;
             
             switch (attacker.Race)
             {

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -614,7 +614,8 @@ namespace Server.MirObjects
             get
             {
                 return 
-                    !Dead && Envir.Time > MoveTime && 
+                    !Dead && 
+                    Envir.Time > MoveTime && 
                     Envir.Time > ActionTime && 
                     Envir.Time > ShockTime &&
                     (Master == null || Master.PMode == PetMode.MoveOnly || Master.PMode == PetMode.Both || Master.PMode == PetMode.FocusMasterTarget) && 
@@ -629,9 +630,10 @@ namespace Server.MirObjects
             get
             {
                 return 
-                    !Dead && Envir.Time > AttackTime &&
+                    !Dead &&
+                    Envir.Time > AttackTime &&
                     Envir.Time > ActionTime &&
-                    (Master == null || Master.PMode == PetMode.AttackOnly || Master.PMode == PetMode.Both || Master.PMode == PetMode.FocusMasterTarget || !CurrentMap.Info.NoFight) &&
+                    (Master == null || Master.PMode == PetMode.AttackOnly || Master.PMode == PetMode.Both || Master.PMode == PetMode.FocusMasterTarget) &&
                     !CurrentPoison.HasFlag(PoisonType.Paralysis) &&
                     !CurrentPoison.HasFlag(PoisonType.LRParalysis) &&
                     !CurrentPoison.HasFlag(PoisonType.Dazed) &&

--- a/Server/MirObjects/NPC/NPCSegment.cs
+++ b/Server/MirObjects/NPC/NPCSegment.cs
@@ -1,6 +1,7 @@
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using System.Globalization;
+using System.Numerics;
 using System.Text.RegularExpressions;
 using S = ServerPackets;
 using Timer = Server.MirEnvir.Timer;
@@ -1435,7 +1436,6 @@ namespace Server.MirObjects
                 case "GUILDWARFEE":
                     newValue = Settings.Guild_WarCost.ToString();
                     break;
-
                 case "PARCELAMOUNT":
                     newValue = player.GetMailAwaitingCollectionAmount().ToString();
                     break;
@@ -1447,7 +1447,26 @@ namespace Server.MirObjects
                 case "ROLLRESULT":
                     newValue = player.NPCData.TryGetValue("NPCRollResult", out object _rollResult) ? _rollResult.ToString() : "Not Rolled";
                     break;
-
+                case "MOUNTLOYALTY":
+                    if (!player.Mount.HasMount)
+                    {
+                        newValue = "No Mount";
+                    }
+                    else
+                    {
+                        newValue = $"{player.Info.Equipment[(int)EquipmentSlot.Mount].CurrentDura}/{player.Info.Equipment[(int)EquipmentSlot.Mount].MaxDura}";
+                    }
+                    break;
+                case "MOUNT":
+                    if (player.Mount.HasMount)
+                    {
+                        newValue = player.Info.Equipment[(int)EquipmentSlot.Mount].FriendlyName;
+                    }
+                    else
+                    {
+                        newValue = "No Mount";
+                    }
+                    break;
                 default:
                     newValue = string.Empty;
                     break;

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -2168,7 +2168,18 @@ namespace Server.MirObjects
                         {
                             if ((!IsGM && !Settings.TestServer) || parts.Length < 2) return;
 
-                            ItemInfo iInfo = Envir.GetItemInfo(parts[1]);
+                            ItemInfo iInfo;
+                            int itemIndex = 0;
+
+                            if (Int32.TryParse(parts[1], out itemIndex))
+                            {
+                                iInfo = Envir.GetItemInfo(itemIndex);
+                            }
+                            else
+                            {
+                                iInfo = Envir.GetItemInfo(parts[1]);
+                            }
+
                             if (iInfo == null) return;
 
                             ushort itemCount = 1;
@@ -2725,7 +2736,18 @@ namespace Server.MirObjects
                             return;
                         }
 
-                        MonsterInfo mInfo = Envir.GetMonsterInfo(parts[1]);
+                        MonsterInfo mInfo = null;
+                        int monsterIndex = 0;
+
+                        if (Int32.TryParse(parts[1], out monsterIndex))
+                        {
+                            mInfo = Envir.GetMonsterInfo(monsterIndex, false);
+                        }
+                        else
+                        {
+                            mInfo = Envir.GetMonsterInfo(parts[1]);
+                        }
+
                         if (mInfo == null)
                         {
                             ReceiveChat((string.Format("Monster {0} does not exist", parts[1])), ChatType.System);
@@ -2757,7 +2779,18 @@ namespace Server.MirObjects
                     case "RECALLMOB":
                         if ((!IsGM && !Settings.TestServer) || parts.Length < 2) return;
 
-                        MonsterInfo mInfo2 = Envir.GetMonsterInfo(parts[1]);
+                        MonsterInfo mInfo2 = null;
+                        int monsterIndex2 = 0;
+
+                        if (Int32.TryParse(parts[1], out monsterIndex2))
+                        {
+                            mInfo2 = Envir.GetMonsterInfo(monsterIndex2, false);
+                        }
+                        else
+                        {
+                            mInfo2 = Envir.GetMonsterInfo(parts[1]);
+                        }
+
                         if (mInfo2 == null) return;
 
                         count = 1;


### PR DESCRIPTION
[Issue 661](https://github.com/Suprcode/mir2/issues/661)
- Gem field names now appear correctly.
- Gem columns will turn yellow to highlight gem specific columns when selected row is a gem or gem dropdown filter is selected.
- They revert back correctly also to non-gem.

[Issue 662](https://github.com/Suprcode/mir2/issues/662)
Bulk update:
- Highlight rows then right click a cell.
- Enter value in popupbox following prompt.
**Note: Does not work for dropdown menus.**

[Issue 758](https://github.com/Suprcode/mir2/issues/758)
- Fix issue with not being able to create new error. Logic around settings Modified to true threw index out of bounds exception.
- Fix issue (https://github.com/Suprcode/mir2/issues/759) where validation of fields was being executed against Index column causing user to never be able to exit this field without deleting new item row.