### PR TITLE
issue-778

### DIFF
--- a/Server/MirObjects/NPC/NPCSegment.cs
+++ b/Server/MirObjects/NPC/NPCSegment.cs
@@ -1454,7 +1454,7 @@ namespace Server.MirObjects
                     }
                     else
                     {
-                        newValue = $"{player.Info.Equipment[(int)EquipmentSlot.Mount].CurrentDura}/{player.Info.Equipment[(int)EquipmentSlot.Mount].MaxDura}";
+                        newValue = $"{player.Info.Equipment[(int)EquipmentSlot.Mount].CurrentDura} ({player.Info.Equipment[(int)EquipmentSlot.Mount].MaxDura})";
                     }
                     break;
                 case "MOUNT":


### PR DESCRIPTION
Change mount loyalty text from:

current/max

to:

current (max)

This stops /max being parsed as a colour.