### PR TITLE
Various Changes (#789)

### DIFF
--- a/Client/Forms/CMain.cs
+++ b/Client/Forms/CMain.cs
@@ -697,6 +697,10 @@ namespace Client
                 GameScene.Scene.ChatDialog.ReceiveChat(string.Format(GameLanguage.CannotLeaveGame, (GameScene.LogTime - CMain.Time) / 1000), ChatType.System);
                 e.Cancel = true;
             }
+            else
+            {
+                Settings.Save();
+            }
         }
 
         protected override void WndProc(ref Message m)

--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -3902,6 +3902,9 @@ namespace Client.MirObjects
                 case Monster.PurpleFaeFlower:
                     if (Stoned) return;
                     break;
+                case Monster.DragonStatue:
+                    SoundManager.PlaySound(BaseSound + 6);
+                    return;
             }
 
             SoundManager.PlaySound(BaseSound);
@@ -3966,6 +3969,13 @@ namespace Client.MirObjects
         }
         public void PlayStruckSound()
         {
+            switch(BaseImage)
+            {
+                case Monster.EvilMir:
+                    SoundManager.PlaySound(SoundList.StruckEvilMir);
+                    return;
+            }
+
             switch (StruckWeapon)
             {
                 case 0:
@@ -4086,6 +4096,8 @@ namespace Client.MirObjects
             switch (BaseImage)
             {
                 case Monster.DarkCaptain:
+                case Monster.EvilMir:
+                case Monster.DragonStatue:
                     return;
                 default:
                     SoundManager.PlaySound(BaseSound + 4);
@@ -4101,6 +4113,7 @@ namespace Client.MirObjects
                     return;
             }
         }
+
         public void PlayDeadSound()
         {
             switch (BaseImage)
@@ -4196,6 +4209,8 @@ namespace Client.MirObjects
                 case Monster.IcePhantom:
                 case Monster.WaterDragon:
                 case Monster.BlackTortoise:
+                case Monster.EvilMir:
+                case Monster.DragonStatue:
                     SoundManager.PlaySound(BaseSound + 5);
                     return;
                 case Monster.AncientBringer:

--- a/Client/MirScenes/Dialogs/BigMapDialog.cs
+++ b/Client/MirScenes/Dialogs/BigMapDialog.cs
@@ -10,7 +10,7 @@ using C = ClientPackets;
 namespace Client.MirScenes.Dialogs
 {
     public sealed class BigMapDialog : MirImageControl
-    {        
+    {
         MirLabel CoordinateLabel, TitleLabel;
         public MirButton CloseButton, ScrollUpButton, ScrollDownButton, ScrollBar, WorldButton, MyLocationButton, TeleportToButton, SearchButton;
         public MirTextBox SearchTextBox;
@@ -73,7 +73,7 @@ namespace Client.MirScenes.Dialogs
                     TeleportToButton.Enabled = false;
                 }
             }
-        }         
+        }
 
         private BigMapRecord currentRecord;
         public BigMapRecord CurrentRecord
@@ -101,11 +101,11 @@ namespace Client.MirScenes.Dialogs
             ScrollUpButton = new MirButton
             {
                 Index = 197,
-                HoverIndex = 198,                
+                HoverIndex = 198,
                 PressedIndex = 199,
                 Location = new Point(Size.Width - 21, 48),
                 Library = Libraries.Prguse2,
-                Parent = this,                
+                Parent = this,
                 Sound = SoundList.ButtonA,
             };
             ScrollUpButton.Click += (o, e) => ScrollUp();
@@ -175,7 +175,7 @@ namespace Client.MirScenes.Dialogs
             {
                 Index = 821,
                 HoverIndex = 822,
-                PressedIndex = 823, 
+                PressedIndex = 823,
                 DisabledIndex = 823,
                 Enabled = false,
                 Location = new Point(Size.Width - 122, 432),
@@ -190,11 +190,12 @@ namespace Client.MirScenes.Dialogs
                 Index = 1340,
                 HoverIndex = 1341,
                 PressedIndex = 1342,
-                Enabled = false,
+                Enabled = true,
                 Location = new Point(23, Size.Height - 36),
                 Library = Libraries.Prguse2,
                 Parent = this,
                 Sound = SoundList.ButtonA,
+                Hint = "Search for NPCs"
             };
             SearchButton.Click += (o, e) => Search();
 
@@ -206,7 +207,6 @@ namespace Client.MirScenes.Dialogs
                 Size = new Size(130, 10),
                 MaxLength = Globals.MaxChatLength
             };
-            SearchTextBox.TextBox.TextChanged += SearchTextBox_TextChanged;
             SearchTextBox.TextBox.KeyPress += SearchTextBox_KeyPress;
 
             ViewPort = new BigMapViewPort()
@@ -234,7 +234,7 @@ namespace Client.MirScenes.Dialogs
             };
 
             WorldMap = new WorldMapImage()
-            {                
+            {
                 Parent = this,
                 Location = new Point(10, 0)
             };
@@ -249,7 +249,9 @@ namespace Client.MirScenes.Dialogs
                 PressedIndex = 362,
                 Sound = SoundList.ButtonA,
             };
-            CloseButton.Click += (o, e) => Hide();            
+            CloseButton.Click += (o, e) => Hide();
+
+            SearchTextBox.Enabled = false;
         }
 
         private void MakeCoordinateLabel()
@@ -286,8 +288,10 @@ namespace Client.MirScenes.Dialogs
             var map = GameScene.Scene.MapControl;
             if (map.BigMap <= 0) return;
 
+            SearchTextBox.Enabled = false;
+
             base.Show();
-            TargetMyLocation();            
+            TargetMyLocation();
         }
 
         private void TargetMyLocation()
@@ -337,7 +341,7 @@ namespace Client.MirScenes.Dialogs
         private void SetMovementButtonsVisibility(bool visible)
         {
             foreach (var button in currentRecord.MovementButtons.Values)
-                button.Visible = visible;            
+                button.Visible = visible;
         }
         private void SetNPCButtonVisibility(bool visible)
         {
@@ -358,7 +362,7 @@ namespace Client.MirScenes.Dialogs
             ScrollBar.Visible = true;
             var scrollHeight = ScrollDownButton.Location.Y - ScrollUpButton.Location.Y - 32;
             var extraRows = currentRecord.NPCButtons.Count - MaximumRows;
-            GapPerRow = scrollHeight / (float)extraRows;            
+            GapPerRow = scrollHeight / (float)extraRows;
         }
 
         public void BigMap_MouseWheel(object sender, MouseEventArgs e)
@@ -413,15 +417,18 @@ namespace Client.MirScenes.Dialogs
 
         private void Search()
         {
+            if (!SearchTextBox.Enabled)
+            {
+                SearchTextBox.Enabled = true;
+                SearchTextBox.SetFocus();
+            }
+
+            if (!string.IsNullOrWhiteSpace(SearchTextBox.Text) && SearchTextBox.Text.Length > 2) return;
+
             if (CMain.Now < NextSearchTime) return;
 
             NextSearchTime = CMain.Now.AddSeconds(1);
             Network.Enqueue(new C.SearchMap { Text = SearchTextBox.Text });
-        }
-
-        private void SearchTextBox_TextChanged(object sender, EventArgs e)
-        {
-            SearchButton.Enabled = !string.IsNullOrWhiteSpace(SearchTextBox.Text) && SearchTextBox.Text.Length > 2;
         }
 
         public void SearchTextBox_KeyPress(object sender, KeyPressEventArgs e)
@@ -479,7 +486,7 @@ namespace Client.MirScenes.Dialogs
                 NotControl = true,
                 Visible = true,
                 Blending = true
-                
+
             };
 
             Border = new MirImageControl()
@@ -625,13 +632,13 @@ namespace Client.MirScenes.Dialogs
         {
             if (!Parent.Visible) return;
 
-            MouseMove -= UpdateBigMapCoordinates;            
+            MouseMove -= UpdateBigMapCoordinates;
 
             BigMapRecord currentRecord;
             if (!GameScene.MapInfoList.TryGetValue(ParentDialog.TargetMapIndex, out currentRecord))
                 return;
 
-            ParentDialog.CurrentRecord = currentRecord;              
+            ParentDialog.CurrentRecord = currentRecord;
             int index = currentRecord.MapInfo.BigMap;
 
             if (index <= 0)
@@ -643,7 +650,7 @@ namespace Client.MirScenes.Dialogs
             Rectangle viewRect = new Rectangle(0, 0, Math.Min(568, Size.Width), Math.Min(380, Size.Height));
 
             viewRect.X = 14 + (568 - viewRect.Width) / 2;
-            viewRect.Y = 52 + (380 - viewRect.Height) / 2;            
+            viewRect.Y = 52 + (380 - viewRect.Height) / 2;
 
             Location = viewRect.Location;
             Size = viewRect.Size;
@@ -848,6 +855,6 @@ namespace Client.MirScenes.Dialogs
         public List<BigMapNPCRow> NPCButtons = new List<BigMapNPCRow>();
 
         public BigMapRecord() { }
-    }  
-   
+    }
+
 }

--- a/Client/MirScenes/Dialogs/HeroDialogs.cs
+++ b/Client/MirScenes/Dialogs/HeroDialogs.cs
@@ -647,11 +647,12 @@ namespace Client.MirScenes.Dialogs
         {
             if (ExperienceBar.Library == null) return;
 
-            double percent = Experience / (double)MaxExperience;
-            if (percent > 1) percent = 1;
-            if (percent <= 0) return;
+            //cast MaxExperience to double to force division to 2 decimal place
+            double percent = Experience / (double)MaxExperience * 100;
 
-            Rectangle section = new Rectangle
+            var test = (int)ExperienceBar.Size.Width * percent;
+
+            Rectangle section = new()
             {
                 Size = new Size((int)(ExperienceBar.Size.Width * percent), ExperienceBar.Size.Height)
             };

--- a/Client/MirScenes/Dialogs/MainDialogs.cs
+++ b/Client/MirScenes/Dialogs/MainDialogs.cs
@@ -2715,7 +2715,6 @@ namespace Client.MirScenes.Dialogs
             };
             MusicSoundBar.MouseDown += MusicSoundBar_MouseMove;
             MusicSoundBar.MouseMove += MusicSoundBar_MouseMove;
-            MusicSoundBar.MouseUp += MusicSoundBar_MouseUp;
             MusicSoundBar.BeforeDraw += MusicSoundBar_BeforeDraw;
 
             MusicVolumeBar = new MirImageControl
@@ -2813,8 +2812,10 @@ namespace Client.MirScenes.Dialogs
             byte volume = (byte)(p.X / (double)SoundBar.Size.Width * 100);
             Settings.Volume = volume;
 
-
             double percent = Settings.Volume / 100D;
+
+            SoundBar.Hint = $"{Settings.Volume}%";
+
             if (percent > 1) percent = 1;
 
             VolumeBar.Location = percent > 0 ? new Point(159 + (int)((SoundBar.Size.Width - 2) * percent), 218) : new Point(159, 218);
@@ -2825,6 +2826,9 @@ namespace Client.MirScenes.Dialogs
             if (SoundBar.Library == null) return;
 
             double percent = Settings.Volume / 100D;
+
+            SoundBar.Hint = $"{Settings.Volume}%";
+
             if (percent > 1) percent = 1;
             if (percent > 0)
             {
@@ -2845,6 +2849,9 @@ namespace Client.MirScenes.Dialogs
             if (MusicSoundBar.Library == null) return;
 
             double percent = Settings.MusicVolume / 100D;
+
+            MusicSoundBar.Hint = $"{Settings.MusicVolume}%";
+
             if (percent > 1) percent = 1;
             if (percent > 0)
             {
@@ -2860,24 +2867,6 @@ namespace Client.MirScenes.Dialogs
                 MusicVolumeBar.Location = new Point(159, 244);
         }
 
-        public void MusicSoundBar_MouseUp(object sender, MouseEventArgs e)
-        {
-            if (SoundManager.MusicVol <= -2900)
-                SoundManager.MusicVol = -3000;
-            if (SoundManager.MusicVol >= -100)
-                SoundManager.MusicVol = 0;
-
-
-            //SoundManager.Device.Dispose();
-            //SoundManager.Create();
-            //SoundManager.PlayMusic(SoundList.Music, true);
-
-            if (SoundManager.Music == null) return;
-
-            SoundManager.Music.SetVolume(SoundManager.MusicVol);
-
-        }
-
         private void MusicSoundBar_MouseMove(object sender, MouseEventArgs e)
         {
             if (e.Button != MouseButtons.Left || MusicSoundBar != ActiveControl) return;
@@ -2887,8 +2876,10 @@ namespace Client.MirScenes.Dialogs
             byte volume = (byte)(p.X / (double)MusicSoundBar.Size.Width * 100);
             Settings.MusicVolume = volume;
 
-
             double percent = Settings.MusicVolume / 100D;
+
+            MusicSoundBar.Hint = $"{Settings.MusicVolume}%";
+
             if (percent > 1) percent = 1;
 
             MusicVolumeBar.Location = percent > 0 ? new Point(159 + (int)((MusicSoundBar.Size.Width - 2) * percent), 244) : new Point(159, 244);

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -5088,7 +5088,8 @@ namespace Client.MirScenes
 
         private void ObjectRangeAttack(S.ObjectRangeAttack p)
         {
-            if (p.ObjectID == User.ObjectID) return;
+            if (p.ObjectID == User.ObjectID &&
+                !Observing) return;
 
             for (int i = MapControl.Objects.Count - 1; i >= 0; i--)
             {

--- a/Client/MirSounds/Libraries/ISoundLibrary.cs
+++ b/Client/MirSounds/Libraries/ISoundLibrary.cs
@@ -6,7 +6,7 @@
         long ExpireTime { get; set; }
 
         bool IsPlaying();
-        void Play();
+        void Play(int volume);
         void Stop();
         void SetVolume(int vol);
 

--- a/Client/MirSounds/Libraries/NullLibrary.cs
+++ b/Client/MirSounds/Libraries/NullLibrary.cs
@@ -19,7 +19,7 @@
             return false;
         }
 
-        public void Play()
+        public void Play(int volume)
         {
             
         }

--- a/Client/MirSounds/Libraries/WavLibrary.cs
+++ b/Client/MirSounds/Libraries/WavLibrary.cs
@@ -16,19 +16,19 @@ namespace Client.MirSounds
         private SoundBufferDescription _desc;
         private readonly byte[] _data;
 
-        public static WavLibrary TryCreate(int index, string fileName, bool loop)
+        public static WavLibrary TryCreate(int index, string fileName, int volume, bool loop)
         {
             fileName = Path.Combine(Settings.SoundPath, Path.GetFileNameWithoutExtension(fileName) + ".wav");
 
             if (File.Exists(fileName))
             {
-                return new WavLibrary(index, fileName, loop);
+                return new WavLibrary(index, fileName, volume, loop);
             }
 
             return null;
         }
 
-        public WavLibrary(int index, string fileName, bool loop)
+        public WavLibrary(int index, string fileName, int volume, bool loop)
         {
             Index = index;
 
@@ -48,7 +48,7 @@ namespace Client.MirSounds
 
             _bufferList = new List<SecondarySoundBuffer>();
 
-            Play();
+            Play(volume);
         }
 
         public bool IsPlaying()
@@ -64,7 +64,7 @@ namespace Client.MirSounds
             return false;
         }
 
-        public void Play()
+        public void Play(int volume)
         {
             if (_stream == null) return;
 
@@ -74,13 +74,13 @@ namespace Client.MirSounds
             {
                 if (_bufferList.Count == 0)
                 {
-                    SecondarySoundBuffer buffer = new SecondarySoundBuffer(SoundManager.Device, _desc) { Volume = SoundManager.Vol };
+                    SecondarySoundBuffer buffer = new SecondarySoundBuffer(SoundManager.Device, _desc) { Volume = volume };
                     buffer.Write(_data, 0, LockFlags.None);
                     _bufferList.Add(buffer);
                 }
                 else if (_bufferList[0] == null || _bufferList[0].Disposed)
                 {
-                    SecondarySoundBuffer buffer = new SecondarySoundBuffer(SoundManager.Device, _desc) { Volume = SoundManager.Vol };
+                    SecondarySoundBuffer buffer = new SecondarySoundBuffer(SoundManager.Device, _desc) { Volume = volume };
                     buffer.Write(_data, 0, LockFlags.None);
                     _bufferList[0] = buffer;
                 }
@@ -100,7 +100,7 @@ namespace Client.MirSounds
 
                     if (_bufferList[i].Status != BufferStatus.Playing)
                     {
-                        _bufferList[i].Volume = SoundManager.Vol;
+                        _bufferList[i].Volume = volume;
                         _bufferList[i].Play(0, 0);
                         return;
                     }
@@ -108,7 +108,7 @@ namespace Client.MirSounds
 
                 if (_bufferList.Count >= Settings.SoundOverLap) return;
 
-                SecondarySoundBuffer buffer = new SecondarySoundBuffer(SoundManager.Device, _desc) { Volume = SoundManager.Vol, Pan = 0 };
+                SecondarySoundBuffer buffer = new SecondarySoundBuffer(SoundManager.Device, _desc) { Volume = volume, Pan = 0 };
                 buffer.Write(_data, 0, LockFlags.None);
                 buffer.Play(0, 0);
                 _bufferList.Add(buffer);

--- a/Client/MirSounds/SoundManager.cs
+++ b/Client/MirSounds/SoundManager.cs
@@ -33,6 +33,7 @@ namespace Client.MirSounds
             {
                 if (_musicVol == value) return;
                 _musicVol = value;
+                AdjustMusicVolume();
             }
         }
 
@@ -111,12 +112,12 @@ namespace Client.MirSounds
             for (int i = 0; i < Sounds.Count; i++)
             {
                 if (Sounds[i].Index != index) continue;
-                Sounds[i].Play();
+                Sounds[i].Play(Vol);
                 return;
             }
 
             if (IndexList.ContainsKey(index))
-                Sounds.Add(GetSound(index, IndexList[index], loop));
+                Sounds.Add(GetSound(index, IndexList[index], Vol, loop));
             else
             {
                 string filename;
@@ -125,13 +126,13 @@ namespace Client.MirSounds
                     index -= 20000;
                     filename = string.Format("M{0:0}-{1:0}", index/10, index%10);
 
-                    Sounds.Add(GetSound(index + 20000, filename, loop));
+                    Sounds.Add(GetSound(index + 20000, filename, Vol, loop));
                 }
                 else if (index < 10000)
                 {
                     filename = string.Format("{0:000}-{1:0}", index/10, index%10);
                     
-                    Sounds.Add(GetSound(index, filename, loop));
+                    Sounds.Add(GetSound(index, filename, Vol, loop));
                 }
             }
         }
@@ -140,9 +141,10 @@ namespace Client.MirSounds
         {
             if (Device == null) return;
 
-            Music = GetSound(index, index.ToString(), true);
-            Music.SetVolume(MusicVol);
-            Music.Play();
+            if (IndexList.TryGetValue(index, out string value))
+            {
+                Music = GetSound(index, value, MusicVol, loop);
+            }
         }
 
         public static void StopMusic()
@@ -151,11 +153,17 @@ namespace Client.MirSounds
             Music?.Dispose();
         }
 
+        static void AdjustMusicVolume()
+        {
+            Music?.SetVolume(MusicVol);
+        }
+
         static void AdjustAllVolumes()
         {
             for (int i = 0; i < Sounds.Count; i++)
-                Sounds[i].Dispose();
-            Sounds.Clear();
+            {
+                Sounds[i].SetVolume(Vol);
+            }        
         }
 
         static void CheckSoundTimeOut()
@@ -181,9 +189,9 @@ namespace Client.MirSounds
             }
         }
 
-        static ISoundLibrary GetSound(int index, string fileName, bool loop)
+        static ISoundLibrary GetSound(int index, string fileName, int volume, bool loop)
         {
-            var sound = WavLibrary.TryCreate(index, fileName, loop);
+            var sound = WavLibrary.TryCreate(index, fileName, volume, loop);
 
             if (sound != null)
             {
@@ -291,6 +299,8 @@ namespace Client.MirSounds
             StruckArmourAxe = 10081,
             StruckArmourLongStick = 10082,
             StruckArmourFist = 10083,
+
+            StruckEvilMir = 10090,
 
             MaleFlinch = 10138,
             FemaleFlinch = 10139,

--- a/Client/Settings.cs
+++ b/Client/Settings.cs
@@ -10,6 +10,12 @@ namespace Client
         private static InIReader Reader = new InIReader(@".\Mir2Config.ini");
         private static InIReader QuestTrackingReader = new InIReader(Path.Combine(UserDataPath, @".\QuestTracking.ini"));
 
+        private const int MIN_VOL_SCALE = -3000;
+        private const int MAX_VOL_SCALE = 0;
+        private const int MIN_MUSIC_SCALE = -7000;
+        private const int MAX_MUSIC_SCALE = 0;
+        private const int MUSIC_OFF = -10000;
+
         private static bool _useTestConfig;
         public static bool UseTestConfig
         {
@@ -95,12 +101,29 @@ namespace Client
             {
                 if (_volume == value) return;
 
-                _volume = (byte) (value > 100 ? 100 : value);
+                switch (value)
+                {
+                    case > 100:
+                        _volume = (byte)100;
+                        break;
+                    case <= 0:
+                        _volume = (byte)0;
+                        break;
+                    default:
+                        _volume = value;
+                        break;
+                }
 
                 if (_volume == 0)
-                    SoundManager.Vol = -10000;
-                else 
-                    SoundManager.Vol = (int)(-3000 + (3000 * (_volume / 100M)));
+                {
+                    SoundManager.Vol = MUSIC_OFF;
+                }
+                else
+                {
+                    double scaled = MIN_VOL_SCALE + (double)(_volume - 0) / (100 - 0) * (MAX_VOL_SCALE - MIN_VOL_SCALE);
+                    SoundManager.Vol = Convert.ToInt32(scaled);
+                }
+
             }
         }
 
@@ -112,12 +135,29 @@ namespace Client
             {
                 if (_musicVolume == value) return;
 
-                _musicVolume = (byte)(value > 100 ? 100 : value);
+                switch(value)
+                {
+                    case > 100:
+                        _musicVolume = (byte)100;
+                        break;
+                    case <= 0:
+                        _musicVolume = (byte)0;
+                        break;
+                    default:
+                        _musicVolume = value;
+                        break;
+                }
 
                 if (_musicVolume == 0)
-                    SoundManager.MusicVol = -10000;
+                {
+                    SoundManager.MusicVol = MUSIC_OFF;
+                }   
                 else
-                    SoundManager.MusicVol = (int)(-3000 + (3000 * (_musicVolume / 100M)));
+                {
+                    double scaled = MIN_MUSIC_SCALE + (double)(_musicVolume - 0) / (100 - 0) * (MAX_MUSIC_SCALE - MIN_MUSIC_SCALE);
+                    SoundManager.MusicVol = Convert.ToInt32(scaled);
+                }
+
             }
         }
 

--- a/Server/MirObjects/NPC/NPCSegment.cs
+++ b/Server/MirObjects/NPC/NPCSegment.cs
@@ -1454,7 +1454,7 @@ namespace Server.MirObjects
                     }
                     else
                     {
-                        newValue = $"{player.Info.Equipment[(int)EquipmentSlot.Mount].CurrentDura}/{player.Info.Equipment[(int)EquipmentSlot.Mount].MaxDura}";
+                        newValue = $"{player.Info.Equipment[(int)EquipmentSlot.Mount].CurrentDura} ({player.Info.Equipment[(int)EquipmentSlot.Mount].MaxDura})";
                     }
                     break;
                 case "MOUNT":


### PR DESCRIPTION
* Deny ability to @mob or @recallmob an IntelligentCreatureObject

* Deny spawning of conquest objects to @MOB and @RECALLMOB

* Hero now instant levels up correctly

* Change mount loyalty text from:

current/max

to:

current (max)

This stops /max being parsed as a colour.

* Archer range attack now draws for observer.

* BigMap improvement:

Show() no longer has search box take focus.
Now have to click magnifying glass to enable search. Allows for all client to handle all other input as normal.

* Refactored some music bar logic - unnecessary event handler to mouse up. Refactored SoundManager and associated classes to take a volume parameter instead of hardcoded to sound volume value. Changed scale for music from -3000 min to -7000 for better low end gains.

* Settings now save on client exit

* Fixed issue with switching wrong variable - sound bar wasnt updating correctly. Hint box now shows realtime volume % as you slide bar for both sound and music volumes. Sound volume now adjusts sounds in real time - before was killing all sound then next sound to play would have new volume % set.

* EvilMir and DragonStatue sound addition.

* Fix audio clip of PlaySwingSound()

* HeroInfopanel shows correct text % and background bar length.

* Fix numbering and add struck SoundList static class.