### PR TITLE
issue-798

### DIFF
--- a/Client/Forms/CMain.cs
+++ b/Client/Forms/CMain.cs
@@ -87,6 +87,8 @@ namespace Client
                 LoadMouseCursors();
                 SetMouseCursor(MouseCursor.Default);
 
+                SlimDX.Configuration.EnableObjectTracking = true;
+
                 DXManager.Create();
                 SoundManager.Create();
                 CenterToScreen();
@@ -700,6 +702,9 @@ namespace Client
             else
             {
                 Settings.Save();
+
+                DXManager.Dispose();
+                SoundManager.Dispose();
             }
         }
 

--- a/Client/MirGraphics/DXManager.cs
+++ b/Client/MirGraphics/DXManager.cs
@@ -576,5 +576,16 @@ namespace Client.MirGraphics
             ControlList.Clear();
         }
 
+        public static void Dispose()
+        {
+            CleanUp();
+
+            Device.Direct3D?.Dispose();
+            Device.Dispose();
+
+            NormalPixelShader?.Dispose();
+            GrayScalePixelShader?.Dispose();
+            MagicPixelShader?.Dispose();
+        }
     }
 }

--- a/Client/MirSounds/SoundManager.cs
+++ b/Client/MirSounds/SoundManager.cs
@@ -200,6 +200,20 @@ namespace Client.MirSounds
 
             return new NullLibrary(index, fileName, loop);
         }
+
+        public static void Dispose()
+        {
+            DelayList.Clear();
+
+            for (int i = Sounds.Count - 1; i >= 0; i--)
+            {
+                Sounds[i]?.Dispose();
+            }
+
+            Music?.Dispose();
+
+            Device?.Dispose();
+        }
     }
 
     public static class SoundList


### PR DESCRIPTION
DXManager, SoundManager and all associated unmanaged resources now clear correctly on exist.  Previously seen anywhere from 350 to 800 objects still alive on client exit through SlimDX. (#799)