### PR TITLE
SlimDX does not dispose of Direct3D9 neatly in full screen causing ma…

### DIFF
--- a/Client/MirGraphics/DXManager.cs
+++ b/Client/MirGraphics/DXManager.cs
@@ -581,7 +581,11 @@ namespace Client.MirGraphics
             CleanUp();
 
             Device.Direct3D?.Dispose();
-            Device.Dispose();
+
+            if (Program.Form.WindowState != FormWindowState.Normal)
+            {
+                Device.Dispose();
+            }
 
             NormalPixelShader?.Dispose();
             GrayScalePixelShader?.Dispose();


### PR DESCRIPTION
…in thread to hang. (#811)

Hotfix is to allow windows to clear memory on client exit for fullscreen and call Dispose() for windows mode.