### PR TITLE
Stonetrap rework and various issues (#817)

### DIFF
--- a/Client/MirControls/MirItemCell.cs
+++ b/Client/MirControls/MirItemCell.cs
@@ -1031,13 +1031,6 @@ namespace Client.MirControls
                                     }
                                 }
 
-                                if (GameScene.SelectedCell.Item.Weight + MapObject.User.CurrentBagWeight > MapObject.User.Stats[Stat.BagWeight])
-                                {
-                                    GameScene.Scene.ChatDialog.ReceiveChat("Too heavy to get back.", ChatType.System);
-                                    GameScene.SelectedCell = null;
-                                    return;
-                                }
-
                                 if (Item != null)
                                 {
                                     if (GameScene.SelectedCell.Item.Info == Item.Info && Item.Count < Item.Info.StackSize)
@@ -1109,13 +1102,6 @@ namespace Client.MirControls
                                     }
                                 }
 
-                                if (GameScene.SelectedCell.Item.Weight + MapObject.User.CurrentBagWeight > MapObject.User.Stats[Stat.BagWeight])
-                                {
-                                    GameScene.Scene.ChatDialog.ReceiveChat("Too heavy to get back.", ChatType.System);
-                                    GameScene.SelectedCell = null;
-                                    return;
-                                }
-
                                 if (Item != null)
                                 {
                                     if (GameScene.SelectedCell.Item.Info == Item.Info && Item.Count < Item.Info.StackSize)
@@ -1181,13 +1167,6 @@ namespace Client.MirControls
                                     }
                                 }
 
-                                if (GameScene.SelectedCell.Item.Weight + MapObject.User.CurrentBagWeight > MapObject.User.Stats[Stat.BagWeight])
-                                {
-                                    GameScene.Scene.ChatDialog.ReceiveChat("Too heavy to get back.", ChatType.System);
-                                    GameScene.SelectedCell = null;
-                                    return;
-                                }
-
                                 if (Item != null)
                                 {
                                     if (GameScene.SelectedCell.Item.Info == Item.Info && Item.Count < Item.Info.StackSize)
@@ -1236,13 +1215,6 @@ namespace Client.MirControls
                                     return;
                                 }
 
-                                if (GameScene.SelectedCell.Item.Weight + MapObject.User.CurrentBagWeight > MapObject.User.Stats[Stat.BagWeight])
-                                {
-                                    GameScene.Scene.ChatDialog.ReceiveChat("Too heavy to get back.", ChatType.System);
-                                    GameScene.SelectedCell = null;
-                                    return;
-                                }
-
                                 if (Item == null)
                                 {
                                     Network.Enqueue(new C.RetrieveRentalItem { From = GameScene.SelectedCell.ItemSlot, To = ItemSlot });
@@ -1270,13 +1242,6 @@ namespace Client.MirControls
                                         GameScene.SelectedCell = null;
                                         return;
                                     }
-                                }
-
-                                if (GameScene.SelectedCell.Item.Weight + MapObject.User.CurrentBagWeight > MapObject.User.Stats[Stat.BagWeight])
-                                {
-                                    GameScene.Scene.ChatDialog.ReceiveChat("Too heavy to transfer.", ChatType.System);
-                                    GameScene.SelectedCell = null;
-                                    return;
                                 }
 
                                 if (Item != null)

--- a/Client/MirNetwork/Network.cs
+++ b/Client/MirNetwork/Network.cs
@@ -10,6 +10,8 @@ namespace Client.MirNetwork
     {
         private static TcpClient _client;
         public static int ConnectAttempt = 0;
+        public static int MaxAttempts = 20;
+        public static bool ErrorShown;
         public static bool Connected;
         public static long TimeOutTime, TimeConnected, RetryTime = CMain.Time + 5000;
 
@@ -24,20 +26,46 @@ namespace Client.MirNetwork
             if (_client != null)
                 Disconnect();
 
+            if (ConnectAttempt >= MaxAttempts)
+            {
+                if (ErrorShown)
+                {
+                    return;
+                }
+
+                ErrorShown = true;
+
+                MirMessageBox errorBox = new("Error Connecting to Server", MirMessageBoxButtons.Cancel);
+                errorBox.CancelButton.Click += (o, e) => Program.Form.Close();
+                errorBox.Label.Text = $"Maximum Connection Attempts Reached: {MaxAttempts}" +
+                                      $"{Environment.NewLine}Please try again later or check your connection settings.";
+                errorBox.Show();
+                return;
+            }
+
             ConnectAttempt++;
 
-            _client = new TcpClient {NoDelay = true};
-            _client.BeginConnect(Settings.IPAddress, Settings.Port, Connection, null);
-
+            try
+            {
+                _client = new TcpClient { NoDelay = true };
+                _client?.BeginConnect(Settings.IPAddress, Settings.Port, Connection, null);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                if (Settings.LogErrors) CMain.SaveError(ex.ToString());
+                Disconnect();
+            }
         }
 
         private static void Connection(IAsyncResult result)
         {
             try
             {
-                _client.EndConnect(result);
+                _client?.EndConnect(result);
 
-                if (!_client.Connected)
+                if ((_client != null &&
+                    !_client.Connected) ||
+                    _client == null)
                 {
                     Connect();
                     return;
@@ -50,11 +78,11 @@ namespace Client.MirNetwork
                 TimeOutTime = CMain.Time + Settings.TimeOut;
                 TimeConnected = CMain.Time;
 
-
                 BeginReceive();
             }
             catch (SocketException)
             {
+                Thread.Sleep(100);
                 Connect();
             }
             catch (Exception ex)
@@ -142,12 +170,11 @@ namespace Client.MirNetwork
             { }
         }
 
-
         public static void Disconnect()
         {
             if (_client == null) return;
 
-            _client.Close();
+            _client?.Close();
 
             TimeConnected = 0;
             Connected = false;

--- a/Client/MirObjects/MapObject.cs
+++ b/Client/MirObjects/MapObject.cs
@@ -190,11 +190,19 @@ namespace Client.MirObjects
             if (MagicObjectID == ObjectID)
                 MagicObject = this;
 
-            /*if (TargetObject == null)
+            if (!this.Dead &&
+                TargetObject == null &&
+                LastTargetObjectId == ObjectID)
             {
-                if (lastTargetObjectId == ObjectID)
-                    TargetObject = this;
-            }*/
+                switch (Race)
+                {
+                    case ObjectType.Player:
+                    case ObjectType.Monster:
+                    case ObjectType.Hero:
+                        TargetObject = this;
+                        break;
+                }
+            }
         }
 
         public void AddBuffEffect(BuffType type)

--- a/Client/MirObjects/UserObject.cs
+++ b/Client/MirObjects/UserObject.cs
@@ -716,15 +716,8 @@ namespace Client.MirObjects
 
         public void GetMaxGain(UserItem item)
         {
-            if (CurrentBagWeight + item.Weight <= Stats[Stat.BagWeight] && FreeSpace(Inventory) > 0) return;
-
             ushort min = 0;
             ushort max = item.Count;
-
-            if (CurrentBagWeight >= Stats[Stat.BagWeight])
-            {
-
-            }
 
             if (item.Info.Type == ItemType.Amulet)
             {
@@ -748,9 +741,9 @@ namespace Client.MirObjects
                     }
                 }
 
-                if (min == 0)
+                if (min == 0 && FreeSpace(Inventory) == 0)
                 {
-                    GameScene.Scene.ChatDialog.ReceiveChat(FreeSpace(Inventory) == 0 ? GameLanguage.NoBagSpace : "You do not have enough weight.", ChatType.System);
+                    GameScene.Scene.ChatDialog.ReceiveChat(GameLanguage.NoBagSpace, ChatType.System);
 
                     item.Count = 0;
                     return;
@@ -760,15 +753,11 @@ namespace Client.MirObjects
                 return;
             }
 
-            if (CurrentBagWeight + item.Weight > Stats[Stat.BagWeight])
+            if (FreeSpace(Inventory) == 0)
             {
-                item.Count = (ushort)(Math.Max((Stats[Stat.BagWeight] - CurrentBagWeight), ushort.MinValue) / item.Info.Weight);
-                max = item.Count;
-                if (item.Count == 0)
-                {
-                    GameScene.Scene.ChatDialog.ReceiveChat("You do not have enough weight.", ChatType.System);
-                    return;
-                }
+                GameScene.Scene.ChatDialog.ReceiveChat(GameLanguage.NoBagSpace, ChatType.System);
+                item.Count = 0;
+                return;
             }
 
             if (item.Info.StackSize > 1)

--- a/Client/MirScenes/Dialogs/NPCDialogs.cs
+++ b/Client/MirScenes/Dialogs/NPCDialogs.cs
@@ -732,12 +732,6 @@ namespace Client.MirScenes.Dialogs
                     return;
                 }
 
-                if (SelectedItem.Weight > (MapObject.User.Stats[Stat.BagWeight] - MapObject.User.CurrentBagWeight))
-                {
-                    GameScene.Scene.ChatDialog.ReceiveChat("You do not have enough weight.", ChatType.System);
-                    return;
-                }
-
                 for (int i = 0; i < MapObject.User.Inventory.Length; i++)
                 {
                     if (MapObject.User.Inventory[i] == null) break;
@@ -1978,12 +1972,6 @@ namespace Client.MirScenes.Dialogs
 
             //TODO - Check Max slots spare against slots to be used (stacksize/quantity)
             //TODO - GetMaxItemGain
-
-            if (RecipeItem.Weight > (MapObject.User.Stats[Stat.BagWeight] - MapObject.User.CurrentBagWeight))
-            {
-                GameScene.Scene.ChatDialog.ReceiveChat("You do not have enough weight.", ChatType.System);
-                return;
-            }
 
             if (max == 1)
             {

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -10403,11 +10403,7 @@ namespace Client.MirScenes
             {
                 if (SetMusic != Music)
                 {
-                    if (SoundManager.Music != null)
-                    {
-                        SoundManager.Music.Dispose();
-                    }
-
+                    SoundManager.Music?.Dispose();
                     SoundManager.PlayMusic(Music, true);
                 }
             }

--- a/Client/MirSounds/Libraries/NAudioLibrary.cs
+++ b/Client/MirSounds/Libraries/NAudioLibrary.cs
@@ -15,6 +15,7 @@ namespace Client.MirSounds.Libraries
         private WaveOutEvent outputDevice;
         private AudioFileReader audioFile;
 
+        private int _unscaledVolume;
         private string _fileName;
         private bool _loop;
         private bool _isDisposing;
@@ -110,7 +111,7 @@ namespace Client.MirSounds.Libraries
             if (_loop &&
                 !_isDisposing)
             {
-                outputDevice.Play();
+                    Play(_unscaledVolume);
             }
         }
 
@@ -124,6 +125,8 @@ namespace Client.MirSounds.Libraries
 
         private float ScaleVolume(int volume)
         {
+            _unscaledVolume = volume;
+
             float scaled = 0.0f + (float)(volume - 0) / (100 - 0) * (1.0f - 0.0f);
             return scaled;
         }

--- a/Server/MirObjects/MapObject.cs
+++ b/Server/MirObjects/MapObject.cs
@@ -200,7 +200,6 @@ namespace Server.MirObjects
 
         }
 
-
         public virtual void Process()
         {
             if (Master != null && Master.Node == null) Master = null;

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -1,6 +1,7 @@
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using Server.MirObjects.Monsters;
+using System.Diagnostics.Eventing.Reader;
 using S = ServerPackets;
 
 namespace Server.MirObjects
@@ -1717,12 +1718,36 @@ namespace Server.MirObjects
                             {
                                 case ObjectType.Monster:
                                 case ObjectType.Hero:
+
                                     if (!ob.IsAttackTarget(this)) continue;
                                     if (ob.Hidden && (!CoolEye || Level < ob.Level)) continue;
                                     if (this is TrapRock && ob.InTrapRock) continue;
-                                    Target = ob;
-                                    return;
+
+                                    if (ob.Race == ObjectType.Monster && 
+                                        ob is StoneTrap)
+                                    {
+                                        if (Target is null || 
+                                            (Target is not null &&
+                                            Target is not StoneTrap))
+                                        {
+                                            Target = ob;
+                                        }
+                                        
+                                        return;
+                                    }
+                                    else
+                                    {
+                                        Target ??= ob;
+                                    }
+                                    continue;
+                                    
                                 case ObjectType.Player:
+
+                                    if (Target != null)
+                                    {
+                                        continue;
+                                    }
+
                                     PlayerObject playerob = (PlayerObject)ob;
                                     if (!ob.IsAttackTarget(this)) continue;
                                     if (playerob.GMGameMaster || ob.Hidden && (!CoolEye || Level < ob.Level) || Envir.Time < HallucinationTime) continue;
@@ -1740,7 +1765,7 @@ namespace Server.MirObjects
                                             break;
                                         }
                                     }
-                                    return;
+                                    continue;
                                 default:
                                     continue;
                             }

--- a/Server/MirObjects/Monsters/StoneTrap.cs
+++ b/Server/MirObjects/Monsters/StoneTrap.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Threading;
 using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;
@@ -11,22 +12,85 @@ namespace Server.MirObjects.Monsters
     public class StoneTrap : MonsterObject
     {
         public bool Summoned;
-        public long AliveTime;
         public long DieTime;
-
 
         protected internal StoneTrap(MonsterInfo info) : base(info)
         {
             Direction = MirDirection.Up;
         }
+
         public override string Name
         {
             get { return Master == null ? Info.GameName : (Dead ? Info.GameName : string.Format("{0}({1})", Info.GameName, Master.Name)); }
             set { throw new NotSupportedException(); }
         }
+
         protected override void ProcessRegen() { }
+
         protected override void Attack() { }
-        protected override void FindTarget() { }
+
+        protected override void ProcessAI()
+        {
+            for (int d = 0; d <= Info.ViewRange; d++)
+            {
+                for (int y = CurrentLocation.Y - d; y <= CurrentLocation.Y + d; y++)
+                {
+                    if (y < 0) continue;
+                    if (y >= CurrentMap.Height) break;
+
+                    for (int x = CurrentLocation.X - d; x <= CurrentLocation.X + d; x += Math.Abs(y - CurrentLocation.Y) == d ? 1 : d * 2)
+                    {
+                        if (x < 0) continue;
+                        if (x >= CurrentMap.Width) break;
+
+                        Cell cell = CurrentMap.GetCell(x, y);
+                        if (!cell.Valid || cell.Objects == null) continue;
+
+                        for (int i = 0; i < cell.Objects.Count; i++)
+                        {
+                            MapObject ob = cell.Objects[i];
+
+                            if (ob == this)
+                            {
+                                continue;
+                            }
+
+                            switch (ob.Race)
+                            {
+                                case ObjectType.Monster:
+                                case ObjectType.Hero:
+
+                                    MonsterInfo mInfo = Envir.GetMonsterInfo(ob.Name);
+                                    if (mInfo == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    MonsterObject monster = MonsterObject.GetMonster(mInfo);
+                                    if (!monster.Dead)
+                                    {
+                                        if (monster.Master == null ||
+                                            (monster.Master != null &&
+                                            monster.IsAttackTarget(this.Master)))
+                                        {
+                                            if (Target != null &&
+                                                Target is StoneTrap &&
+                                                Target != this)
+                                            {
+                                                continue;
+                                            }
+
+                                            monster.Target = this;
+                                        }     
+                                    }
+
+                                    break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         public override void Turn(MirDirection dir)
         {
@@ -38,77 +102,26 @@ namespace Server.MirObjects.Monsters
         public override void Spawned()
         {
             base.Spawned();
-            AliveTime = Envir.Time + 15000;
             Summoned = true;
         }
         public override void Process()
         {
-            if (!Dead && Summoned)
+            if (!Dead &&
+                Master != null)
             {
-                bool selfDestruct = false;
-                if (Master != null)
+                if (Master.CurrentMap != CurrentMap ||
+                    Envir.Time > DieTime ||
+                    !Functions.InRange(Master.CurrentLocation, CurrentLocation, 15))
                 {
-                    if (Master.CurrentMap != CurrentMap) selfDestruct = true;
-                    if (!Functions.InRange(Master.CurrentLocation, CurrentLocation, 15)) selfDestruct = true;
-                    if (Summoned && Envir.Time > AliveTime) selfDestruct = true;
-                    if (selfDestruct)
-                    {
-                        Die();
-                        //DieTime = Envir.Time + 3000;
-                    }
-                    base.Process();
+                    Die();
+                } 
+                else
+                {
+                    FindTarget();
                 }
             }
+
             base.Process();
-            //else if (Envir.Time >= DieTime) Despawn();
-        }
-
-        public override int Attacked(MonsterObject attacker, int damage, DefenceType type = DefenceType.ACAgility)
-        {
-            int armour = 0;
-
-            switch (type)
-            {
-                case DefenceType.ACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetDefencePower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.AC:
-                    armour = GetDefencePower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.MACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetDefencePower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.MAC:
-                    armour = GetDefencePower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.Agility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    break;
-            }
-
-            if (armour >= damage) return 0;
-
-            ShockTime = 0;
-
-            if (attacker.Info.AI == 6)
-                EXPOwner = null;
-            else if (attacker.Master != null)
-            {
-                if (EXPOwner == null || EXPOwner.Dead)
-                    EXPOwner = attacker.Master;
-
-                if (EXPOwner == attacker.Master)
-                    EXPOwnerTime = Envir.Time + EXPOwnerDelay;
-
-            }
-
-            Broadcast(new S.ObjectStruck { ObjectID = ObjectID, AttackerID = attacker.ObjectID, Direction = Direction, Location = CurrentLocation });
-
-            ChangeHP(-1);
-            return 1;
-
         }
 
         public override int Struck(int damage, DefenceType type = DefenceType.ACAgility)
@@ -116,56 +129,6 @@ namespace Server.MirObjects.Monsters
             return 0;
         }
 
-        public override int Attacked(HumanObject attacker, int damage, DefenceType type = DefenceType.ACAgility, bool damageWeapon = true)
-        {
-            int armour = 0;
-
-            switch (type)
-            {
-                case DefenceType.ACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetDefencePower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.AC:
-                    armour = GetDefencePower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.MACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetDefencePower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.MAC:
-                    armour = GetDefencePower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.Agility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    break;
-            }
-
-            if (armour >= damage) return 0;
-
-            if (damageWeapon)
-                attacker.DamageWeapon();
-
-            ShockTime = 0;
-
-            if (Master != null && Master != attacker)
-                if (Envir.Time > Master.BrownTime && Master.PKPoints < 200)
-                    attacker.BrownTime = Envir.Time + Settings.Minute;
-
-            if (EXPOwner == null || EXPOwner.Dead)
-                EXPOwner = attacker;
-
-            if (EXPOwner == attacker)
-                EXPOwnerTime = Envir.Time + EXPOwnerDelay;
-
-            Broadcast(new S.ObjectStruck { ObjectID = ObjectID, AttackerID = attacker.ObjectID, Direction = Direction, Location = CurrentLocation });
-            attacker.GatherElement();
-            ChangeHP(-1);
-
-            return 1;
-        }
-
-        public override void ApplyPoison(Poison p, MapObject Caster = null, bool NoResist = false, bool ignoreDefence = true) { }
         public override Packet GetInfo()
         {
             return new S.ObjectMonster

--- a/Server/MirObjects/NPC/NPCSegment.cs
+++ b/Server/MirObjects/NPC/NPCSegment.cs
@@ -2940,7 +2940,7 @@ namespace Server.MirObjects
                                     item.Count = item.Info.StackSize;
                                 }
 
-                                if (player.CanGainItem(item, false))
+                                if (player.CanGainItem(item))
                                     player.GainItem(item);
                             }
                         }
@@ -4064,7 +4064,7 @@ namespace Server.MirObjects
 
                                         if (drop.QuestRequired) continue;
 
-                                        if (player.CanGainItem(item, false))
+                                        if (player.CanGainItem(item))
                                         {
                                             player.GainItem(item);
                                         }

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -2207,7 +2207,7 @@ namespace Server.MirObjects
                                     item = Envir.CreateDropItem(iInfo);
                                     item.Count = itemCount;
 
-                                    if (CanGainItem(item, false)) GainItem(item);
+                                    if (CanGainItem(item)) GainItem(item);
 
                                     return;
                                 }
@@ -2215,7 +2215,7 @@ namespace Server.MirObjects
                                 item.Count = iInfo.StackSize;
                                 itemCount -= iInfo.StackSize;
 
-                                if (!CanGainItem(item, false)) return;
+                                if (!CanGainItem(item)) return;
                                 GainItem(item);
                             }
 
@@ -5161,13 +5161,6 @@ namespace Server.MirObjects
                 return;
             }
 
-            if (temp.Weight + CurrentBagWeight > Stats[Stat.BagWeight])
-            {
-                ReceiveChat("Too heavy to get back.", ChatType.System);
-                Enqueue(p);
-                return;
-            }
-
             if (Info.Inventory[to] == null)
             {
                 Info.Inventory[to] = temp;
@@ -5361,13 +5354,6 @@ namespace Server.MirObjects
 
             if (temp == null)
             {
-                Enqueue(p);
-                return;
-            }
-
-            if (temp.Weight + CurrentBagWeight > Stats[Stat.BagWeight])
-            {
-                ReceiveChat("Too heavy to transfer.", ChatType.System);
                 Enqueue(p);
                 return;
             }
@@ -9477,12 +9463,6 @@ namespace Server.MirObjects
                         Enqueue(p);
                         return;
                     }
-                    if (Stats[Stat.BagWeight] < CurrentBagWeight + MyGuild.StoredItems[from].Item.Weight)
-                    {
-                        ReceiveChat("Too overweight to retrieve item.", ChatType.System);
-                        Enqueue(p);
-                        return;
-                    }
                     if (MyGuild.StoredItems[from].Item.Info.Bind.HasFlag(BindMode.DontStore))
                     {
                         Enqueue(p);
@@ -9739,13 +9719,6 @@ namespace Server.MirObjects
 
             if (temp == null)
             {
-                Enqueue(p);
-                return;
-            }
-
-            if (temp.Weight + CurrentBagWeight > Stats[Stat.BagWeight])
-            {
-                ReceiveChat("Too heavy to get back.", ChatType.System);
                 Enqueue(p);
                 return;
             }
@@ -11340,7 +11313,7 @@ namespace Server.MirObjects
             UserItem item = Envir.CreateDropItem(iInfo);
             item.Count = 1;
 
-            if (!CanGainItem(item, false))
+            if (!CanGainItem(item))
             {
                 MailInfo mail = new MailInfo(Info.Index)
                 {
@@ -11679,13 +11652,6 @@ namespace Server.MirObjects
                 return;
             }
 
-            if (temp.Weight + CurrentBagWeight > Stats[Stat.BagWeight])
-            {
-                ReceiveChat("Too heavy to get back.", ChatType.System);
-                Enqueue(p);
-                return;
-            }
-
             if (Info.Inventory[to] == null)
             {
                 Info.Inventory[to] = temp;
@@ -11970,14 +11936,6 @@ namespace Server.MirObjects
             if (Info.CollectTime > Envir.Time)
             {
                 ReceiveChat(string.Format("Your {0} will be ready to collect in {1} minute(s).", Info.CurrentRefine.FriendlyName, ((Info.CollectTime - Envir.Time) / Settings.Minute)), ChatType.System);
-                Enqueue(p);
-                return;
-            }
-
-
-            if (Info.CurrentRefine.Info.Weight + CurrentBagWeight > Stats[Stat.BagWeight])
-            {
-                ReceiveChat(string.Format("Your {0} is too heavy to get back, try again after reducing your bag weight.", Info.CurrentRefine.FriendlyName), ChatType.System);
                 Enqueue(p);
                 return;
             }
@@ -13299,13 +13257,6 @@ namespace Server.MirObjects
                 return;
             }
 
-            if (item.Weight + CurrentBagWeight > Stats[Stat.BagWeight])
-            {
-                ReceiveChat("Item is too heavy to retrieve.", ChatType.System);
-                Enqueue(packet);
-                return;
-            }
-
             if (Info.Inventory[to] == null)
             {
                 Info.Inventory[to] = item;
@@ -13690,7 +13641,7 @@ namespace Server.MirObjects
 
             UserItem item = Envir.CreateFreshItem(itemInfo);            
             item.AddedStats[Stat.Hero] = CurrentHero.Index;
-            if (CanGainItem(item, false))
+            if (CanGainItem(item))
                 GainItem(item);
 
             CurrentHero.SealCount++;

--- a/Shared/ServerPackets.cs
+++ b/Shared/ServerPackets.cs
@@ -4212,7 +4212,7 @@ namespace ServerPackets
          * 2: Already Sold.
          * 3: Expired.
          * 4: Not enough Gold.
-         * 5: Too heavy or not enough bag space.
+         * 5: Not enough bag space.
          * 6: You cannot buy your own items.
          * 7: Trust Merchant is too far.
          * 8: Too much Gold.


### PR DESCRIPTION
* Added delay of 100ms for socket error in connection.  This gave time for Disconnect to gracefully dispose of TcpClient and therefore unbind socket. Added MaxAttempts int (default 20)
When MaxAttempts reached, message box will appear and no more attempts will be made.

* blink and slashingburst attack lock fix

* Stonetrap now taunts enemies which matches official. Only one Stonetrap pet allowed (chat message will appear to tell you this).  Stonetrap will not teleport in recast. Duration time fixed to magic level * 5 + 10  in seconds. MapObject now supports Taunter. This check is done in Process() and sets target.  Note: Taunt swap is not instant. Slight delay due to delayed actions.

* Remove taunt feature Logic handled in ProcessAI for StoneTrap and FindTarget for Monster

* Remove all traces of player bag weight check. Hero weight checks still in place to prevent bag abuse.

* Fixed issue with looping music not working.